### PR TITLE
build(xcode): add team shared workspace checks file

### DIFF
--- a/ios/AndroidStartupPerfApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/AndroidStartupPerfApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Apparently, having a shared file prevents Xcode from constantly rebuilding the Xcode checks.

## References
> Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace's shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace. (37293167)
- https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html
- https://stackoverflow.com/a/50368149/11455106