### PR TITLE
feat(stack): add simple react navigation example

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,18 @@
     "lint": "eslint . --ext .ts,.tsx --cache --quiet"
   },
   "dependencies": {
+    "@react-navigation/native": "^6.0.13",
+    "@react-navigation/native-stack": "^6.9.1",
+    "@react-navigation/stack": "^6.3.2",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-expressions": "^1.3.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "react": "17.0.2",
-    "react-native": "0.66.4"
+    "react-native": "0.66.4",
+    "react-native-safe-area-context": "^4.4.1",
+    "react-native-screens": "^3.18.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const App = () => {
     <NavigationContainer>
       <RootStack.Navigator>
         <RootStack.Screen name="Home" component={HomeScreen} />
+        <RootStack.Screen name="Details" component={DetailsScreen} />
       </RootStack.Navigator>
     </NavigationContainer>
   );
@@ -31,6 +32,14 @@ const HomeScreen = () => {
   return (
     <View style={styles.screenContainer}>
       <Text>Home Screen</Text>
+    </View>
+  );
+};
+
+const DetailsScreen = () => {
+  return (
+    <View style={styles.screenContainer}>
+      <Text>Details Screen</Text>
     </View>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,19 @@ import { StyleSheet, Text, View } from 'react-native';
 
 export const APP_NAME = 'AndroidStartupPerfApp';
 
-const RootStack = createNativeStackNavigator();
+// NOTE: Don't use interface. Don't extend (extends) or intersect (&) with ParamsListBase, either.
+//
+// React Navigation Stack Navigator's ParamListBase generic type
+// goes absolutely loco with Record<string, unknown | object>!
+//
+// When you don't extend it, RouteNames work, but your custom params "don't".
+// When you extend it, RouteNames IntelliSense stops working.
+type RootStackParamList = {
+  Home: undefined;
+  Details: undefined;
+};
+
+const RootStack = createNativeStackNavigator<RootStackParamList>();
 
 const App = () => {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const RootStack = createNativeStackNavigator();
 const App = () => {
   return (
     <NavigationContainer>
-      <RootStack.Navigator>
+      <RootStack.Navigator initialRouteName="Home">
         <RootStack.Screen name="Home" component={HomeScreen} />
         <RootStack.Screen name="Details" component={DetailsScreen} />
       </RootStack.Navigator>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,9 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Text } from 'react-native';
+
+import ScreenView from './ScreenView';
 
 export const APP_NAME = 'AndroidStartupPerfApp';
 
@@ -42,26 +44,18 @@ const App = () => {
 
 const HomeScreen = () => {
   return (
-    <View style={styles.screenContainer}>
+    <ScreenView>
       <Text>Home Screen</Text>
-    </View>
+    </ScreenView>
   );
 };
 
 const DetailsScreen = () => {
   return (
-    <View style={styles.screenContainer}>
+    <ScreenView>
       <Text>Details Screen</Text>
-    </View>
+    </ScreenView>
   );
 };
-
-const styles = StyleSheet.create({
-  screenContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,9 @@
 
 import { NavigationContainer, NavigationProp, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import React from 'react';
-import { Button, Text, TextInput, View } from 'react-native';
+import React, { createContext, useContext, useState } from 'react';
+import { Button, Text, TextInput, TextProps, View } from 'react-native';
+import ConditionalText from './ConditionalText';
 
 import ScreenView from './ScreenView';
 
@@ -24,7 +25,7 @@ export const APP_NAME = 'AndroidStartupPerfApp';
 //
 // When you don't extend it, RouteNames work, but your custom params "don't".
 // When you extend it, RouteNames IntelliSense stops working.
-type RootStackParamList = {
+type FlowStackParamList = {
   Home: undefined;
   Step1: undefined;
   Step2: undefined;
@@ -33,7 +34,7 @@ type RootStackParamList = {
   Complete: undefined;
 };
 
-const ROOT_STACK_KEYS: (keyof RootStackParamList)[] = [
+const ROOT_STACK_KEYS: (keyof FlowStackParamList)[] = [
   // multiline
   'Home',
   'Step1',
@@ -43,14 +44,14 @@ const ROOT_STACK_KEYS: (keyof RootStackParamList)[] = [
   'Complete',
 ];
 
-const useRootStackNavigatorNavigate = () => {
-  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+const useFlowStackNavigatorNavigate = () => {
+  const navigator = useNavigation<NavigationProp<FlowStackParamList>>();
   const navigateTo = ROOT_STACK_KEYS.reduce((navigateToFinal, key) => {
     navigateToFinal[key] = () => {
       navigator.navigate(key);
     };
     return navigateToFinal;
-  }, {} as Record<keyof RootStackParamList, () => void>);
+  }, {} as Record<keyof FlowStackParamList, () => void>);
 
   return {
     navigator,
@@ -58,25 +59,126 @@ const useRootStackNavigatorNavigate = () => {
   };
 };
 
-const RootStack = createNativeStackNavigator<RootStackParamList>();
+const FlowStack = createNativeStackNavigator<FlowStackParamList>();
+
+interface FlowStateContextValue {
+  step1: {
+    value: boolean;
+    setValue: React.Dispatch<React.SetStateAction<boolean>>;
+    resetValue: () => void;
+  };
+  step2: {
+    value: string;
+    setValue: React.Dispatch<React.SetStateAction<string>>;
+    resetValue: () => void;
+  };
+  step3: {
+    value: string;
+    setValue: React.Dispatch<React.SetStateAction<string>>;
+    resetValue: () => void;
+  };
+}
+
+const DEFAULT_FLOW_STATE_CONTEXT_VALUE: FlowStateContextValue = {
+  step1: {
+    value: false,
+    setValue: () => {},
+    resetValue: () => {},
+  },
+  step2: {
+    value: '',
+    setValue: () => {},
+    resetValue: () => {},
+  },
+  step3: {
+    value: '',
+    setValue: () => {},
+    resetValue: () => {},
+  },
+};
+
+const FlowStateContext = createContext(DEFAULT_FLOW_STATE_CONTEXT_VALUE);
+const useFlowStateContextValue = (): FlowStateContextValue => {
+  const [ step1Value, setStep1Value ] = useState(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step1.value);
+  const resetStep1Value = () => {
+    setStep1Value(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step1.value);
+  };
+
+  const [ step2Value, setStep2Value ] = useState(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step2.value);
+  const resetStep2Value = () => {
+    setStep2Value(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step2.value);
+  };
+
+  const [ step3Value, setStep3Value ] = useState(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step3.value);
+  const resetStep3Value = () => {
+    setStep3Value(DEFAULT_FLOW_STATE_CONTEXT_VALUE.step3.value);
+  };
+
+  return {
+    step1: {
+      value: step1Value,
+      setValue: setStep1Value,
+      resetValue: resetStep1Value,
+    },
+    step2: {
+      value: step2Value,
+      setValue: setStep2Value,
+      resetValue: resetStep2Value,
+    },
+    step3: {
+      value: step3Value,
+      setValue: setStep3Value,
+      resetValue: resetStep3Value,
+    },
+  };
+};
+
+// Imitate useState API as that's all the client code cares about.
+// The useContext behavior under the hood is abstracted from the client code.
+type FlowStateContextHook<Key extends keyof FlowStateContextValue> = [
+  FlowStateContextValue[Key]['value'],
+  FlowStateContextValue[Key]['setValue'],
+  FlowStateContextValue[Key]['resetValue'],
+];
+
+/**
+ * Selects a slice from the state context using a slice key.
+ * @template Key Any of the known state context keys (`step1`, `step2`, `step3`, ...).
+ * @param step The state context slice key to select.
+ * @returns The state context slice.
+ */
+const useFlowStateContext = <Key extends keyof FlowStateContextValue>(step: Key): FlowStateContextHook<Key> => {
+  const context = useContext<FlowStateContextValue>(FlowStateContext);
+  const { value, setValue, resetValue } = context[step];
+
+  return [
+    value,
+    setValue,
+    resetValue,
+  ];
+};
 
 const App = () => {
+  const flowDataStateContextValue = useFlowStateContextValue();
+
   return (
-    <NavigationContainer>
-      <RootStack.Navigator initialRouteName="Home">
-        <RootStack.Screen name="Home" component={HomeScreen} />
-        <RootStack.Screen name="Step1" component={Step1Screen} />
-        <RootStack.Screen name="Step2" component={Step2Screen} />
-        <RootStack.Screen name="Step3" component={Step3Screen} />
-        <RootStack.Screen name="Review" component={ReviewScreen} />
-        <RootStack.Screen name="Complete" component={CompleteScreen} />
-      </RootStack.Navigator>
-    </NavigationContainer>
+    <FlowStateContext.Provider value={flowDataStateContextValue}>
+      <NavigationContainer>
+        <FlowStack.Navigator initialRouteName="Home">
+          <FlowStack.Screen name="Home" component={HomeScreen} />
+          <FlowStack.Screen name="Step1" component={Step1Screen} />
+          <FlowStack.Screen name="Step2" component={Step2Screen} />
+          <FlowStack.Screen name="Step3" component={Step3Screen} />
+          <FlowStack.Screen name="Review" component={ReviewScreen} />
+          <FlowStack.Screen name="Complete" component={CompleteScreen} />
+        </FlowStack.Navigator>
+      </NavigationContainer>
+    </FlowStateContext.Provider>
   );
 };
 
 const HomeScreen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const { navigateTo } = useFlowStackNavigatorNavigate();
 
   return (
     <ScreenView>
@@ -87,7 +189,15 @@ const HomeScreen = () => {
 };
 
 const Step1Screen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const [ step1State, setStep1State ] = useFlowStateContext('step1');
+  const { navigateTo } = useFlowStackNavigatorNavigate();
+  const buttonTitle = !step1State ? 'Agree' : 'Disagree';
+  const buttonColor = !step1State ? undefined : 'red';
+  const handleButtonPress = () => {
+    setStep1State((value) => {
+      return !value;
+    });
+  };
 
   return (
     <ScreenView>
@@ -99,20 +209,26 @@ const Step1Screen = () => {
         <View>
           <Text>Read the Privacy Policy.</Text>
         </View>
+        <ConditionalText show={step1State}>Agreed!</ConditionalText>
+        <Button title={buttonTitle} onPress={handleButtonPress} color={buttonColor} />
       </View>
-      <Button title="Step 2" onPress={navigateTo.Step2} />
+      <Button title="Step 2" onPress={navigateTo.Step2} disabled={!step1State} />
     </ScreenView>
   );
 };
 
 const Step2Screen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const [ step2Value, setStep2State ] = useFlowStateContext('step2');
+  const { navigateTo } = useFlowStackNavigatorNavigate();
+  const handleInputChange = (value: string) => {
+    setStep2State(value);
+  };
 
   return (
     <ScreenView>
       <Text>Step 2: Input</Text>
       <View>
-        <TextInput placeholder="Dummy input" />
+        <TextInput placeholder="Dummy input." value={step2Value} onChangeText={handleInputChange} />
       </View>
       <Button title="Step 3" onPress={navigateTo.Step3} />
     </ScreenView>
@@ -120,14 +236,17 @@ const Step2Screen = () => {
 };
 
 const Step3Screen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const [ step3Value, setStep3State ] = useFlowStateContext('step3');
+  const { navigateTo } = useFlowStackNavigatorNavigate();
+  const handleInputChange = (value: string) => {
+    setStep3State(value);
+  };
 
   return (
     <ScreenView>
       <Text>Step 3: More input</Text>
       <View>
-        <TextInput placeholder="Dummy input" />
-        <TextInput placeholder="More dummy input!" />
+        <TextInput placeholder="More dummy input!" value={step3Value} onChangeText={handleInputChange} />
       </View>
       <Button title="Review Details" onPress={navigateTo.Review} />
     </ScreenView>
@@ -135,7 +254,23 @@ const Step3Screen = () => {
 };
 
 const ReviewScreen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const [ step1Value, _setStep1Value, resetStep1Value ] = useFlowStateContext('step1');
+  const step1Text = step1Value ? 'Agreed' : 'Disagreed';
+
+  const [ step2Value, _setStep2Value, resetStep2Value ] = useFlowStateContext('step2');
+  const step2Text = step2Value;
+
+  const [ step3Value, _setStep3Value, resetStep3Value ] = useFlowStateContext('step3');
+  const step3Text = step3Value;
+
+  const { navigateTo } = useFlowStackNavigatorNavigate();
+
+  const handleStartOverButtonPress = () => {
+    resetStep1Value();
+    resetStep2Value();
+    resetStep3Value();
+    navigateTo.Home();
+  };
 
   return (
     <ScreenView>
@@ -143,26 +278,39 @@ const ReviewScreen = () => {
       <View>
         <Text>Here are your input details.</Text>
         <Text>Go through them. Verify that they're good to go.</Text>
-        <Text>Step 2 dummy input.</Text>
-        <Text>Step 3 dummy input.</Text>
-        <Text>Step 3 more dummy input.</Text>
+        <Text>Step 1: {step1Text}</Text>
+        <Text>Step 2: {step2Text}</Text>
+        <Text>Step 3: {step3Text}</Text>
       </View>
-      <Button title="Start over" onPress={navigateTo.Home} />
+      <Button title="Start over" color="red" onPress={handleStartOverButtonPress} />
       <Button title="Submit" onPress={navigateTo.Complete} />
     </ScreenView>
   );
 };
 
 const CompleteScreen = () => {
-  const { navigateTo } = useRootStackNavigatorNavigate();
+  const [ _step1Value, _setStep1Value, resetStep1Value ] = useFlowStateContext('step1');
+
+  const [ _step2Value, _setStep2Value, resetStep2Value ] = useFlowStateContext('step2');
+
+  const [ _step3Value, _setStep3Value, resetStep3Value ] = useFlowStateContext('step3');
+
+  const { navigateTo } = useFlowStackNavigatorNavigate();
+
+  const handleStartOverButtonPress = () => {
+    resetStep1Value();
+    resetStep2Value();
+    resetStep3Value();
+    navigateTo.Home();
+  };
 
   return (
     <ScreenView>
-      <Text>Complete Screen</Text>
+      <Text>Complete</Text>
       <View>
         <Text>Great! You're all set.</Text>
       </View>
-      <Button title="Start over" onPress={navigateTo.Home} />
+      <Button title="Start over" onPress={handleStartOverButtonPress} />
     </ScreenView>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@
 import { NavigationContainer, NavigationProp, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, Text } from 'react-native';
+import { Button, Text, View } from 'react-native';
 
 import ScreenView from './ScreenView';
 
@@ -27,6 +27,7 @@ export const APP_NAME = 'AndroidStartupPerfApp';
 type RootStackParamList = {
   Home: undefined;
   Details: undefined;
+  Third: undefined;
 };
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -37,6 +38,7 @@ const App = () => {
       <RootStack.Navigator initialRouteName="Home">
         <RootStack.Screen name="Home" component={HomeScreen} />
         <RootStack.Screen name="Details" component={DetailsScreen} />
+        <RootStack.Screen name="Third" component={ThirdScreen} />
       </RootStack.Navigator>
     </NavigationContainer>
   );
@@ -61,10 +63,40 @@ const DetailsScreen = () => {
   const navigateToHome = () => {
     navigator.navigate('Home');
   };
+  const navigateToThird = () => {
+    navigator.navigate('Third');
+  };
 
   return (
     <ScreenView>
       <Text>Details Screen</Text>
+      <View>
+        <Text>This is the second screen on this stack.</Text>
+        <Text>Details of certain wonderful things are presented here.</Text>
+      </View>
+      <Button title="Go to Home" onPress={navigateToHome} />
+      <Button title="Go to Third" onPress={navigateToThird} />
+    </ScreenView>
+  );
+};
+
+const ThirdScreen = () => {
+  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigateToDetails = () => {
+    navigator.navigate('Details');
+  };
+  const navigateToHome = () => {
+    navigator.navigate('Home');
+  };
+
+  return (
+    <ScreenView>
+      <Text>Third Screen</Text>
+      <View>
+        <Text>This is the last screen on this stack.</Text>
+        <Text>There are no further new screens to find.</Text>
+      </View>
+      <Button title="Go to Details" onPress={navigateToDetails} />
       <Button title="Go to Home" onPress={navigateToHome} />
     </ScreenView>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,10 @@
  * @format
  */
 
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, NavigationProp, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Text } from 'react-native';
+import { Button, Text } from 'react-native';
 
 import ScreenView from './ScreenView';
 
@@ -43,17 +43,29 @@ const App = () => {
 };
 
 const HomeScreen = () => {
+  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigateToDetails = () => {
+    navigator.navigate('Details');
+  };
+
   return (
     <ScreenView>
       <Text>Home Screen</Text>
+      <Button title="Go to Details" onPress={navigateToDetails} />
     </ScreenView>
   );
 };
 
 const DetailsScreen = () => {
+  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigateToHome = () => {
+    navigator.navigate('Home');
+  };
+
   return (
     <ScreenView>
       <Text>Details Screen</Text>
+      <Button title="Go to Home" onPress={navigateToHome} />
     </ScreenView>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ type RootStackParamList = {
   Home: undefined;
   Details: undefined;
   Third: undefined;
+  Final: undefined;
 };
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -39,6 +40,7 @@ const App = () => {
         <RootStack.Screen name="Home" component={HomeScreen} />
         <RootStack.Screen name="Details" component={DetailsScreen} />
         <RootStack.Screen name="Third" component={ThirdScreen} />
+        <RootStack.Screen name="Final" component={FinalScreen} />
       </RootStack.Navigator>
     </NavigationContainer>
   );
@@ -85,13 +87,35 @@ const ThirdScreen = () => {
   const navigateToDetails = () => {
     navigator.navigate('Details');
   };
+  const navigateToFinal = () => {
+    navigator.navigate('Final');
+  };
+
+  return (
+    <ScreenView>
+      <Text>Third Screen</Text>
+      <View>
+        <Text>This is the third screen on this stack.</Text>
+        <Text>I padded this content to add more screens to the stack.</Text>
+      </View>
+      <Button title="Go to Details" onPress={navigateToDetails} />
+      <Button title="Go to Final" onPress={navigateToFinal} />
+    </ScreenView>
+  );
+};
+
+const FinalScreen = () => {
+  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigateToDetails = () => {
+    navigator.navigate('Third');
+  };
   const navigateToHome = () => {
     navigator.navigate('Home');
   };
 
   return (
     <ScreenView>
-      <Text>Third Screen</Text>
+      <Text>Final Screen</Text>
       <View>
         <Text>This is the last screen on this stack.</Text>
         <Text>There are no further new screens to find.</Text>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Sample React Native App
+ * React Native App with React Navigation
  * https://github.com/facebook/react-native
  *
  * Generated with the TypeScript template
@@ -8,100 +8,38 @@
  * @format
  */
 
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, useColorScheme, View } from 'react-native';
-
-import {
-  Colors,
-  DebugInstructions,
-  Header,
-  LearnMoreLinks,
-  ReloadInstructions,
-} from 'react-native/Libraries/NewAppScreen';
+import { StyleSheet, Text, View } from 'react-native';
 
 export const APP_NAME = 'AndroidStartupPerfApp';
 
-const Section: React.FC<{
-  title: string;
-}> = ({ children, title }) => {
-  const isDarkMode = useColorScheme() === 'dark';
+const RootStack = createNativeStackNavigator();
+
+const App = () => {
   return (
-    <View style={styles.sectionContainer}>
-      <Text
-        style={[
-          styles.sectionTitle,
-          {
-            color: isDarkMode ? Colors.white : Colors.black,
-          },
-        ]}
-      >
-        {title}
-      </Text>
-      <Text
-        style={[
-          styles.sectionDescription,
-          {
-            color: isDarkMode ? Colors.light : Colors.dark,
-          },
-        ]}
-      >
-        {children}
-      </Text>
+    <NavigationContainer>
+      <RootStack.Navigator>
+        <RootStack.Screen name="Home" component={HomeScreen} />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+const HomeScreen = () => {
+  return (
+    <View style={styles.screenContainer}>
+      <Text>Home Screen</Text>
     </View>
   );
 };
 
-const App = () => {
-  const isDarkMode = useColorScheme() === 'dark';
-
-  const backgroundStyle = {
-    backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
-  };
-
-  return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <ScrollView contentInsetAdjustmentBehavior="automatic" style={backgroundStyle}>
-        <Header />
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}
-        >
-          <Section title="Step One">
-            Edit <Text style={styles.highlight}>App.tsx</Text> to change this screen and then come back to see your
-            edits.
-          </Section>
-          <Section title="See Your Changes">
-            <ReloadInstructions />
-          </Section>
-          <Section title="Debug">
-            <DebugInstructions />
-          </Section>
-          <Section title="Learn More">Read the docs to discover what to do next:</Section>
-          <LearnMoreLinks />
-        </View>
-      </ScrollView>
-    </SafeAreaView>
-  );
-};
-
 const styles = StyleSheet.create({
-  sectionContainer: {
-    marginTop: 32,
-    paddingHorizontal: 24,
-  },
-  sectionTitle: {
-    fontSize: 24,
-    fontWeight: '600',
-  },
-  sectionDescription: {
-    marginTop: 8,
-    fontSize: 18,
-    fontWeight: '400',
-  },
-  highlight: {
-    fontWeight: '700',
+  screenContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@
 import { NavigationContainer, NavigationProp, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, Text, View } from 'react-native';
+import { Button, Text, TextInput, View } from 'react-native';
 
 import ScreenView from './ScreenView';
 
@@ -26,9 +26,36 @@ export const APP_NAME = 'AndroidStartupPerfApp';
 // When you extend it, RouteNames IntelliSense stops working.
 type RootStackParamList = {
   Home: undefined;
-  Details: undefined;
-  Third: undefined;
-  Final: undefined;
+  Step1: undefined;
+  Step2: undefined;
+  Step3: undefined;
+  Review: undefined;
+  Complete: undefined;
+};
+
+const ROOT_STACK_KEYS: (keyof RootStackParamList)[] = [
+  // multiline
+  'Home',
+  'Step1',
+  'Step2',
+  'Step3',
+  'Review',
+  'Complete',
+];
+
+const useRootStackNavigatorNavigate = () => {
+  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigateTo = ROOT_STACK_KEYS.reduce((navigateToFinal, key) => {
+    navigateToFinal[key] = () => {
+      navigator.navigate(key);
+    };
+    return navigateToFinal;
+  }, {} as Record<keyof RootStackParamList, () => void>);
+
+  return {
+    navigator,
+    navigateTo,
+  };
 };
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -38,90 +65,104 @@ const App = () => {
     <NavigationContainer>
       <RootStack.Navigator initialRouteName="Home">
         <RootStack.Screen name="Home" component={HomeScreen} />
-        <RootStack.Screen name="Details" component={DetailsScreen} />
-        <RootStack.Screen name="Third" component={ThirdScreen} />
-        <RootStack.Screen name="Final" component={FinalScreen} />
+        <RootStack.Screen name="Step1" component={Step1Screen} />
+        <RootStack.Screen name="Step2" component={Step2Screen} />
+        <RootStack.Screen name="Step3" component={Step3Screen} />
+        <RootStack.Screen name="Review" component={ReviewScreen} />
+        <RootStack.Screen name="Complete" component={CompleteScreen} />
       </RootStack.Navigator>
     </NavigationContainer>
   );
 };
 
 const HomeScreen = () => {
-  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
-  const navigateToDetails = () => {
-    navigator.navigate('Details');
-  };
+  const { navigateTo } = useRootStackNavigatorNavigate();
 
   return (
     <ScreenView>
-      <Text>Home Screen</Text>
-      <Button title="Go to Details" onPress={navigateToDetails} />
+      <Text>Home</Text>
+      <Button title="Start" onPress={navigateTo.Step1} />
     </ScreenView>
   );
 };
 
-const DetailsScreen = () => {
-  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
-  const navigateToHome = () => {
-    navigator.navigate('Home');
-  };
-  const navigateToThird = () => {
-    navigator.navigate('Third');
-  };
+const Step1Screen = () => {
+  const { navigateTo } = useRootStackNavigatorNavigate();
 
   return (
     <ScreenView>
-      <Text>Details Screen</Text>
+      <Text>Step 1: Consent</Text>
       <View>
-        <Text>This is the second screen on this stack.</Text>
-        <Text>Details of certain wonderful things are presented here.</Text>
+        <View>
+          <Text>Read the Terms & Conditions.</Text>
+        </View>
+        <View>
+          <Text>Read the Privacy Policy.</Text>
+        </View>
       </View>
-      <Button title="Go to Home" onPress={navigateToHome} />
-      <Button title="Go to Third" onPress={navigateToThird} />
+      <Button title="Step 2" onPress={navigateTo.Step2} />
     </ScreenView>
   );
 };
 
-const ThirdScreen = () => {
-  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
-  const navigateToDetails = () => {
-    navigator.navigate('Details');
-  };
-  const navigateToFinal = () => {
-    navigator.navigate('Final');
-  };
+const Step2Screen = () => {
+  const { navigateTo } = useRootStackNavigatorNavigate();
 
   return (
     <ScreenView>
-      <Text>Third Screen</Text>
+      <Text>Step 2: Input</Text>
       <View>
-        <Text>This is the third screen on this stack.</Text>
-        <Text>I padded this content to add more screens to the stack.</Text>
+        <TextInput placeholder="Dummy input" />
       </View>
-      <Button title="Go to Details" onPress={navigateToDetails} />
-      <Button title="Go to Final" onPress={navigateToFinal} />
+      <Button title="Step 3" onPress={navigateTo.Step3} />
     </ScreenView>
   );
 };
 
-const FinalScreen = () => {
-  const navigator = useNavigation<NavigationProp<RootStackParamList>>();
-  const navigateToDetails = () => {
-    navigator.navigate('Third');
-  };
-  const navigateToHome = () => {
-    navigator.navigate('Home');
-  };
+const Step3Screen = () => {
+  const { navigateTo } = useRootStackNavigatorNavigate();
 
   return (
     <ScreenView>
-      <Text>Final Screen</Text>
+      <Text>Step 3: More input</Text>
       <View>
-        <Text>This is the last screen on this stack.</Text>
-        <Text>There are no further new screens to find.</Text>
+        <TextInput placeholder="Dummy input" />
+        <TextInput placeholder="More dummy input!" />
       </View>
-      <Button title="Go to Details" onPress={navigateToDetails} />
-      <Button title="Go to Home" onPress={navigateToHome} />
+      <Button title="Review Details" onPress={navigateTo.Review} />
+    </ScreenView>
+  );
+};
+
+const ReviewScreen = () => {
+  const { navigateTo } = useRootStackNavigatorNavigate();
+
+  return (
+    <ScreenView>
+      <Text>Review your details</Text>
+      <View>
+        <Text>Here are your input details.</Text>
+        <Text>Go through them. Verify that they're good to go.</Text>
+        <Text>Step 2 dummy input.</Text>
+        <Text>Step 3 dummy input.</Text>
+        <Text>Step 3 more dummy input.</Text>
+      </View>
+      <Button title="Start over" onPress={navigateTo.Home} />
+      <Button title="Submit" onPress={navigateTo.Complete} />
+    </ScreenView>
+  );
+};
+
+const CompleteScreen = () => {
+  const { navigateTo } = useRootStackNavigatorNavigate();
+
+  return (
+    <ScreenView>
+      <Text>Complete Screen</Text>
+      <View>
+        <Text>Great! You're all set.</Text>
+      </View>
+      <Button title="Start over" onPress={navigateTo.Home} />
     </ScreenView>
   );
 };

--- a/src/ConditionalText.tsx
+++ b/src/ConditionalText.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+
+interface ConditionalTextProps extends TextProps {
+  show?: boolean;
+}
+const ConditionalText = (props: ConditionalTextProps) => {
+  const { show = false, ...rest } = props;
+
+  if (!show) {
+    return null;
+  }
+
+  // eslint-disable-next-line prettier/prettier
+  return (
+    <Text {...rest as unknown as TextProps} />
+  );
+};
+
+export default ConditionalText;

--- a/src/ScreenView.tsx
+++ b/src/ScreenView.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleSheet, View, ViewProps } from 'react-native';
+
+const ScreenView = (props: Pick<ViewProps, 'children'>) => {
+  // eslint-disable-next-line prettier/prettier
+  return (
+    <View style={styles.screenContainer}>
+      {props.children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  screenContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default ScreenView;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,57 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@react-navigation/core@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.0.tgz#c44d33a8d8ef010a102c7f831fc8add772678509"
+  integrity sha512-tpc0Ak/DiHfU3LlYaRmIY7vI4sM/Ru0xCet6runLUh9aABf4wiLgxyFJ5BtoWq6xFF8ymYEA/KWtDhetQ24YiA==
+  dependencies:
+    "@react-navigation/routers" "^6.1.3"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.23"
+    query-string "^7.0.0"
+    react-is "^16.13.0"
+    use-latest-callback "^0.1.5"
+
+"@react-navigation/elements@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.6.tgz#fa700318528db93f05144b1be4b691b9c1dd1abe"
+  integrity sha512-pNJ8R9JMga6SXOw6wGVN0tjmE6vegwPmJBL45SEMX2fqTfAk2ykDnlJHodRpHpAgsv0DaI8qX76z3A+aqKSU0w==
+
+"@react-navigation/native-stack@^6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.9.1.tgz#6013300e4cd0b33e242aa18593e4dff7db2ab3d1"
+  integrity sha512-aOuJP97ge6NRz8wH6sDKfLTfdygGmraYh0apKrrVbGvMnflbPX4kpjQiAQcUPUpMeas0betH/Su8QubNL8HEkg==
+  dependencies:
+    "@react-navigation/elements" "^1.3.6"
+    warn-once "^0.1.0"
+
+"@react-navigation/native@^6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.13.tgz#ec504120e193ea6a7f24ffa765a1338be5a3160a"
+  integrity sha512-CwaJcAGbhv3p3ECablxBkw8QBCGDWXqVRwQ4QbelajNW623m3sNTC9dOF6kjp8au6Rg9B5e0KmeuY0xWbPk79A==
+  dependencies:
+    "@react-navigation/core" "^6.4.0"
+    escape-string-regexp "^4.0.0"
+    fast-deep-equal "^3.1.3"
+    nanoid "^3.1.23"
+
+"@react-navigation/routers@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.1.3.tgz#1df51959e9a67c44367462e8b929b7360a5d2555"
+  integrity sha512-idJotMEzHc3haWsCh7EvnnZMKxvaS4YF/x2UyFBkNFiEFUaEo/1ioQU6qqmVLspdEv4bI/dLm97hQo7qD8Yl7Q==
+  dependencies:
+    nanoid "^3.1.23"
+
+"@react-navigation/stack@^6.3.2":
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.3.2.tgz#ba0a65e10e2b165185f20718046f25d8c9abb076"
+  integrity sha512-wb8koMp4OTrG5geOqEFPDatTyl8dsSyRBHN4h0wzgNT29V/JjkS3LYwkGLLfUmMfeLXFyIfEPILAjYLFmnk3dA==
+  dependencies:
+    "@react-navigation/elements" "^1.3.6"
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -2299,10 +2350,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^1.0.7:
   version "1.4.0"
@@ -3201,6 +3268,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+
 finalhandler@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -3717,6 +3789,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -5100,6 +5177,11 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanoid@^3.1.23:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5661,6 +5743,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+query-string@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
@@ -5684,12 +5776,17 @@ react-devtools-core@^4.13.0:
     shell-quote "^1.6.1"
     ws "^7"
 
+react-freeze@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.3.tgz#5e3ca90e682fed1d73a7cb50c2c7402b3e85618d"
+  integrity sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-is@^16.13.1:
+react-is@^16.13.0, react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5707,6 +5804,19 @@ react-native-codegen@^0.0.7:
     flow-parser "^0.121.0"
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
+
+react-native-safe-area-context@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz#239c60b8a9a80eac70a38a822b04c0f1d15ffc01"
+  integrity sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==
+
+react-native-screens@^3.18.2:
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.2.tgz#d7ab2d145258d3db9fa630fa5379dc4474117866"
+  integrity sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native@0.66.4:
   version "0.66.4"
@@ -6225,6 +6335,13 @@ simple-plist@^1.0.0:
     bplist-parser "0.3.1"
     plist "^3.0.5"
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -6353,6 +6470,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
   integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -6406,6 +6528,11 @@ stream-buffers@2.2.x:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -6880,6 +7007,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-latest-callback@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.5.tgz#a4a836c08fa72f6608730b5b8f4bbd9c57c04f51"
+  integrity sha512-HtHatS2U4/h32NlkhupDsPlrbiD27gSH5swBdtXbCAlc6pfOFzaj0FehW/FO12rx8j2Vy4/lJScCiJyM01E+bQ==
+
 use-subscription@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.8.0.tgz#f118938c29d263c2bce12fc5585d3fe694d4dbce"
@@ -6969,6 +7101,11 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warn-once@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.1.tgz#952088f4fb56896e73fd4e6a3767272a3fccce43"
+  integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary
We add new screens to test the limits of native stack navigation with future experiments. The stack is built like this, from top to bottom:

1. Home
2. Step 1
3. Step 2
4. Step 3
5. Review
6. Complete

No 3rd-party global state management libraries are used outside of the React `Context` API.

## References
- React Navigation native stack screen transition fundamentals: https://reactnavigation.org/docs/getting-started
- React Navigation in TypeScript: https://reactnavigation.org/docs/typescript
- React Context: https://beta.reactjs.org/learn/passing-data-deeply-with-context