### PR TITLE
feat(app): use Android basic activity example from boilerplate

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,6 +187,15 @@ android {
 
         }
     }
+
+    /**
+     * Android native class binding to XML view layouts.
+     * Used in referenced to: com.androidstartupperfapp.databinding
+     * This is required for navigation to work in Android native.
+     */
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -194,7 +203,15 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
+    // Seems like these are the last versions that will support API 30.
+    // - androidx.appcompat:appcompat:1.3.1
+    // - androidx.navigation:navigation-* 2.3.5
+    // Any further and the app won't compile.
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "androidx.navigation:navigation-fragment:2.3.5"
+    implementation "androidx.navigation:navigation-ui:2.3.5"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'
@@ -216,6 +233,17 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    // Tried 1.6.2, but receives this on compile time at minCompileSdk 30:
+    // AAPT: error: resource android:color/system_neutral1_1000 not found.
+    // Stick to 1.4.0 for now.
+    // https://stackoverflow.com/a/69065309/11455106
+    //
+    // So, what do we lose?
+    // Dynamic colors support using the newer theme API from Material 3 is
+    // practically nonexistent until Android S (a.k.a API 31).
+    // Until then, accent colors have to be applied directly on the layout.
+    implementation "com.google.android.material:material:1.4.0"
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/com/androidstartupperfapp/FirstFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/FirstFragment.java
@@ -1,0 +1,45 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import com.androidstartupperfapp.databinding.FirstFragmentBinding;
+
+public class FirstFragment extends Fragment {
+
+  private FirstFragmentBinding binding;
+
+  @Override
+  public View onCreateView(
+    LayoutInflater inflater, ViewGroup container,
+    Bundle savedInstanceState
+  ) {
+    binding = FirstFragmentBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    binding.firstButton.setOnClickListener(this::onFirstButtonClick);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+
+  private void onFirstButtonClick(View view) {
+    NavHostFragment
+      .findNavController(FirstFragment.this)
+      .navigate(R.id.action_FirstFragment_to_SecondFragment);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
@@ -1,15 +1,67 @@
 package com.androidstartupperfapp;
 
-import com.facebook.react.ReactActivity;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 
-public class MainActivity extends ReactActivity {
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import androidx.navigation.ui.AppBarConfiguration;
+import androidx.navigation.ui.NavigationUI;
 
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
+import com.androidstartupperfapp.databinding.MainActivityBinding;
+import com.google.android.material.snackbar.Snackbar;
+
+public class MainActivity extends AppCompatActivity {
+
+  private AppBarConfiguration appBarConfiguration;
+  private MainActivityBinding binding;
+
   @Override
-  protected String getMainComponentName() {
-    return "AndroidStartupPerfApp";
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    binding = MainActivityBinding.inflate(getLayoutInflater());
+    setContentView(binding.getRoot());
+
+    setSupportActionBar(binding.toolbar);
+
+    NavController navController = Navigation.findNavController(this, R.id.nav_host_main_content_fragment);
+    appBarConfiguration = new AppBarConfiguration.Builder(navController.getGraph()).build();
+    NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+
+    binding.fab
+      .setOnClickListener(view -> Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
+      .setAction("Action", null).show());
+  }
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // Handle action bar item clicks here. The action bar will
+    // automatically handle clicks on the Home/Up button, so long
+    // as you specify a parent activity in AndroidManifest.xml.
+    int id = item.getItemId();
+
+    //noinspection SimplifiableIfStatement
+    if (id == R.id.action_settings) {
+      return true;
+    }
+
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    NavController navController = Navigation.findNavController(this, R.id.nav_host_main_content_fragment);
+    return NavigationUI.navigateUp(navController, appBarConfiguration)
+      || super.onSupportNavigateUp();
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
@@ -1,78 +1,10 @@
 package com.androidstartupperfapp;
 
 import android.app.Application;
-import android.content.Context;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.soloader.SoLoader;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
-    @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
-    }
-
-    @Override
-    protected List<ReactPackage> getPackages() {
-      @SuppressWarnings("UnnecessaryLocalVariable")
-      List<ReactPackage> packages = new PackageList(this).getPackages();
-      // Packages that cannot be autolinked yet can be added manually here, for example:
-      // packages.add(new MyReactNativePackage());
-      return packages;
-    }
-
-    @Override
-    protected String getJSMainModuleName() {
-      return "index";
-    }
-  };
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
+public class MainApplication extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
-    MainApplication.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-
-  /**
-   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
-   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-   *
-   * @param context
-   * @param reactInstanceManager
-   */
-  private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
-    if (BuildConfig.DEBUG) {
-      try {
-        /*
-         We use reflection here to pick up the class that initializes Flipper,
-        since Flipper library is not available in release mode
-        */
-        Class<?> aClass = Class.forName("com.androidstartupperfapp.ReactNativeFlipper");
-        aClass
-          .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
-          .invoke(null, context, reactInstanceManager);
-      } catch (ClassNotFoundException e) {
-        e.printStackTrace();
-      } catch (NoSuchMethodException e) {
-        e.printStackTrace();
-      } catch (IllegalAccessException e) {
-        e.printStackTrace();
-      } catch (InvocationTargetException e) {
-        e.printStackTrace();
-      }
-    }
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
@@ -1,0 +1,45 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import com.androidstartupperfapp.databinding.SecondFragmentBinding;
+
+public class SecondFragment extends Fragment {
+
+  private SecondFragmentBinding binding;
+
+  @Override
+  public View onCreateView(
+    LayoutInflater inflater, ViewGroup container,
+    Bundle savedInstanceState
+  ) {
+    binding = SecondFragmentBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    binding.secondButton.setOnClickListener(this::onSecondButtonClick);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+
+  private void onSecondButtonClick(View view) {
+    NavHostFragment
+      .findNavController(SecondFragment.this)
+      .navigate(R.id.action_SecondFragment_to_FirstFragment);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/FirstFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/FirstFragment.java
@@ -1,4 +1,4 @@
-package com.androidstartupperfapp;
+package com.androidstartupperfapp.screens;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -9,18 +9,19 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.androidstartupperfapp.databinding.SecondFragmentBinding;
+import com.androidstartupperfapp.R;
+import com.androidstartupperfapp.databinding.FirstFragmentBinding;
 
-public class SecondFragment extends Fragment {
+public class FirstFragment extends Fragment {
 
-  private SecondFragmentBinding binding;
+  private FirstFragmentBinding binding;
 
   @Override
   public View onCreateView(
     LayoutInflater inflater, ViewGroup container,
     Bundle savedInstanceState
   ) {
-    binding = SecondFragmentBinding.inflate(inflater, container, false);
+    binding = FirstFragmentBinding.inflate(inflater, container, false);
     return binding.getRoot();
   }
 
@@ -28,7 +29,7 @@ public class SecondFragment extends Fragment {
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    binding.secondButton.setOnClickListener(this::onSecondButtonClick);
+    binding.firstButton.setOnClickListener(this::onFirstButtonClick);
   }
 
   @Override
@@ -37,9 +38,9 @@ public class SecondFragment extends Fragment {
     binding = null;
   }
 
-  private void onSecondButtonClick(View view) {
+  private void onFirstButtonClick(View view) {
     NavHostFragment
-      .findNavController(SecondFragment.this)
-      .navigate(R.id.action_SecondFragment_to_FirstFragment);
+      .findNavController(FirstFragment.this)
+      .navigate(R.id.action_FirstFragment_to_SecondFragment);
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/FirstFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/FirstFragment.java
@@ -29,7 +29,7 @@ public class FirstFragment extends Fragment {
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    binding.firstButton.setOnClickListener(this::onFirstButtonClick);
+    binding.firstNavToSecondButton.setOnClickListener(this::onFirstNavToSecondButtonClick);
   }
 
   @Override
@@ -38,7 +38,7 @@ public class FirstFragment extends Fragment {
     binding = null;
   }
 
-  private void onFirstButtonClick(View view) {
+  private void onFirstNavToSecondButtonClick(View view) {
     NavHostFragment
       .findNavController(FirstFragment.this)
       .navigate(R.id.action_FirstFragment_to_SecondFragment);

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
@@ -29,7 +29,7 @@ public class SecondFragment extends Fragment {
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    binding.secondButton.setOnClickListener(this::onSecondButtonClick);
+    binding.secondNavToThirdButton.setOnClickListener(this::onSecondNavToThirdButtonClick);
   }
 
   @Override
@@ -38,9 +38,9 @@ public class SecondFragment extends Fragment {
     binding = null;
   }
 
-  private void onSecondButtonClick(View view) {
+  private void onSecondNavToThirdButtonClick(View view) {
     NavHostFragment
       .findNavController(SecondFragment.this)
-      .navigate(R.id.action_SecondFragment_to_FirstFragment);
+      .navigate(R.id.action_SecondFragment_to_ThirdFragment);
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
@@ -1,4 +1,4 @@
-package com.androidstartupperfapp;
+package com.androidstartupperfapp.screens;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -9,18 +9,19 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.androidstartupperfapp.databinding.FirstFragmentBinding;
+import com.androidstartupperfapp.R;
+import com.androidstartupperfapp.databinding.SecondFragmentBinding;
 
-public class FirstFragment extends Fragment {
+public class SecondFragment extends Fragment {
 
-  private FirstFragmentBinding binding;
+  private SecondFragmentBinding binding;
 
   @Override
   public View onCreateView(
     LayoutInflater inflater, ViewGroup container,
     Bundle savedInstanceState
   ) {
-    binding = FirstFragmentBinding.inflate(inflater, container, false);
+    binding = SecondFragmentBinding.inflate(inflater, container, false);
     return binding.getRoot();
   }
 
@@ -28,7 +29,7 @@ public class FirstFragment extends Fragment {
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    binding.firstButton.setOnClickListener(this::onFirstButtonClick);
+    binding.secondButton.setOnClickListener(this::onSecondButtonClick);
   }
 
   @Override
@@ -37,9 +38,9 @@ public class FirstFragment extends Fragment {
     binding = null;
   }
 
-  private void onFirstButtonClick(View view) {
+  private void onSecondButtonClick(View view) {
     NavHostFragment
-      .findNavController(FirstFragment.this)
-      .navigate(R.id.action_FirstFragment_to_SecondFragment);
+      .findNavController(SecondFragment.this)
+      .navigate(R.id.action_SecondFragment_to_FirstFragment);
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/ThirdFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/ThirdFragment.java
@@ -1,0 +1,37 @@
+package com.androidstartupperfapp.screens;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.androidstartupperfapp.databinding.ThirdFragmentBinding;
+
+public class ThirdFragment extends Fragment {
+
+  private ThirdFragmentBinding binding;
+
+  @Override
+  public View onCreateView(
+    LayoutInflater inflater, ViewGroup container,
+    Bundle savedInstanceState
+  ) {
+    binding = ThirdFragmentBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+}

--- a/android/app/src/main/res/anim/slide_in_left.xml
+++ b/android/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:anim/linear_interpolator">
+  <translate
+    android:duration="500"
+    android:fromXDelta="100%"
+    android:fromYDelta="0%"
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
+  <alpha
+    android:duration="300"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0" />
+</set>

--- a/android/app/src/main/res/anim/slide_in_right.xml
+++ b/android/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:anim/linear_interpolator">
+  <translate
+    android:duration="500"
+    android:fromXDelta="50%"
+    android:fromYDelta="0%"
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
+  <alpha
+    android:duration="300"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0" />
+</set>

--- a/android/app/src/main/res/anim/slide_out_left.xml
+++ b/android/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:anim/linear_interpolator">
+  <translate
+    android:duration="500"
+    android:fromXDelta="100%"
+    android:fromYDelta="0%"
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
+  <alpha
+    android:duration="300"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />
+</set>

--- a/android/app/src/main/res/anim/slide_out_right.xml
+++ b/android/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:interpolator="@android:anim/linear_interpolator">
+  <translate
+    android:duration="500"
+    android:fromXDelta="50%"
+    android:fromYDelta="0%"
+    android:toXDelta="0%"
+    android:toYDelta="0%" />
+  <alpha
+    android:duration="300"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />
+</set>

--- a/android/app/src/main/res/layout/first_fragment.xml
+++ b/android/app/src/main/res/layout/first_fragment.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".FirstFragment">
+  tools:context=".screens.FirstFragment">
 
   <TextView
     android:id="@+id/first_textview"

--- a/android/app/src/main/res/layout/first_fragment.xml
+++ b/android/app/src/main/res/layout/first_fragment.xml
@@ -11,13 +11,13 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:text="@string/hello_first_fragment"
-    app:layout_constraintBottom_toTopOf="@id/first_button"
+    app:layout_constraintBottom_toTopOf="@id/first_nav_to_second_button"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
   <Button
-    android:id="@+id/first_button"
+    android:id="@+id/first_nav_to_second_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:backgroundTint="@color/purple_500"

--- a/android/app/src/main/res/layout/first_fragment.xml
+++ b/android/app/src/main/res/layout/first_fragment.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".FirstFragment">
+
+  <TextView
+    android:id="@+id/first_textview"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/hello_first_fragment"
+    app:layout_constraintBottom_toTopOf="@id/first_button"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+    android:id="@+id/first_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:backgroundTint="@color/purple_500"
+    android:text="@string/next"
+    android:textColor="@color/white"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/first_textview" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/main_activity.xml
+++ b/android/app/src/main/res/layout/main_activity.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".MainActivity">
+
+  <com.google.android.material.appbar.AppBarLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:theme="@style/Theme.AndroidStartupPerfApp.AppBarOverlay">
+
+    <androidx.appcompat.widget.Toolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      android:background="@color/purple_500"
+      app:popupTheme="@style/Theme.AndroidStartupPerfApp.PopupOverlay" />
+
+  </com.google.android.material.appbar.AppBarLayout>
+
+  <include layout="@layout/main_content" />
+
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:id="@+id/fab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:layout_marginEnd="@dimen/fab_margin"
+    android:layout_marginBottom="16dp"
+    app:srcCompat="@android:drawable/ic_dialog_email" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/main_content.xml
+++ b/android/app/src/main/res/layout/main_content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+  <fragment
+    android:id="@+id/nav_host_main_content_fragment"
+    android:name="androidx.navigation.fragment.NavHostFragment"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    app:defaultNavHost="true"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintRight_toRightOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".SecondFragment">
+
+  <TextView
+    android:id="@+id/second_textview"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toTopOf="@id/second_button"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+    android:id="@+id/second_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:backgroundTint="@color/purple_500"
+    android:text="@string/previous"
+    android:textColor="@color/white"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/second_textview" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -10,6 +10,7 @@
     android:id="@+id/second_textview"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:text="@string/hello_second_fragment"
     app:layout_constraintBottom_toTopOf="@id/second_button"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".SecondFragment">
+  tools:context=".screens.SecondFragment">
 
   <TextView
     android:id="@+id/second_textview"

--- a/android/app/src/main/res/layout/third_fragment.xml
+++ b/android/app/src/main/res/layout/third_fragment.xml
@@ -4,27 +4,27 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".screens.SecondFragment">
+  tools:context=".screens.ThirdFragment">
 
   <TextView
-    android:id="@+id/second_textview"
+    android:id="@+id/third_textview"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:text="@string/hello_second_fragment"
-    app:layout_constraintBottom_toTopOf="@id/second_nav_to_third_button"
+    android:text="@string/hello_third_fragment"
+    app:layout_constraintBottom_toTopOf="@id/show_react_fragment_button"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
   <Button
-    android:id="@+id/second_nav_to_third_button"
+    android:id="@+id/show_react_fragment_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:backgroundTint="@color/purple_500"
-    android:text="@string/next"
+    android:backgroundTint="@color/teal_700"
+    android:text="@string/show_react_fragment"
     android:textColor="@color/white"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/second_textview" />
+    app:layout_constraintTop_toBottomOf="@id/third_textview" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  tools:context="com.androidstartupperfapp.MainActivity">
+  <item
+    android:id="@+id/action_settings"
+    android:orderInCategory="100"
+    android:title="@string/action_settings"
+    app:showAsAction="never" />
+</menu>

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/nav_graph"
+  app:startDestination="@id/FirstFragment">
+
+  <fragment
+    android:id="@+id/FirstFragment"
+    android:name="com.androidstartupperfapp.FirstFragment"
+    android:label="@string/first_fragment_label"
+    tools:layout="@layout/first_fragment">
+
+    <action
+      android:id="@+id/action_FirstFragment_to_SecondFragment"
+      app:destination="@id/SecondFragment"
+      app:enterAnim="@anim/slide_in_right"
+      app:exitAnim="@anim/slide_out_left"
+      app:popEnterAnim="@anim/slide_in_left"
+      app:popExitAnim="@anim/slide_out_right" />
+  </fragment>
+  <fragment
+    android:id="@+id/SecondFragment"
+    android:name="com.androidstartupperfapp.SecondFragment"
+    android:label="@string/second_fragment_label"
+    tools:layout="@layout/second_fragment">
+
+    <action
+      android:id="@+id/action_SecondFragment_to_FirstFragment"
+      app:destination="@id/FirstFragment"
+      app:enterAnim="@anim/slide_in_right"
+      app:exitAnim="@anim/slide_out_left"
+      app:popEnterAnim="@anim/slide_in_left"
+      app:popExitAnim="@anim/slide_out_right" />
+  </fragment>
+</navigation>

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
   <fragment
     android:id="@+id/FirstFragment"
-    android:name="com.androidstartupperfapp.FirstFragment"
+    android:name="com.androidstartupperfapp.screens.FirstFragment"
     android:label="@string/first_fragment_label"
     tools:layout="@layout/first_fragment">
 
@@ -21,7 +21,7 @@
   </fragment>
   <fragment
     android:id="@+id/SecondFragment"
-    android:name="com.androidstartupperfapp.SecondFragment"
+    android:name="com.androidstartupperfapp.screens.SecondFragment"
     android:label="@string/second_fragment_label"
     tools:layout="@layout/second_fragment">
 

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -32,5 +32,26 @@
       app:exitAnim="@anim/slide_out_left"
       app:popEnterAnim="@anim/slide_in_left"
       app:popExitAnim="@anim/slide_out_right" />
+    <action
+      android:id="@+id/action_SecondFragment_to_ThirdFragment"
+      app:destination="@id/ThirdFragment"
+      app:enterAnim="@anim/slide_in_right"
+      app:exitAnim="@anim/slide_out_left"
+      app:popEnterAnim="@anim/slide_in_left"
+      app:popExitAnim="@anim/slide_out_right" />
+  </fragment>
+  <fragment
+    android:id="@+id/ThirdFragment"
+    android:name="com.androidstartupperfapp.screens.ThirdFragment"
+    android:label="@string/third_fragment_label"
+    tools:layout="@layout/third_fragment">
+
+    <action
+      android:id="@+id/action_ThirdFragment_to_SecondFragment"
+      app:destination="@id/SecondFragment"
+      app:enterAnim="@anim/slide_in_right"
+      app:exitAnim="@anim/slide_out_left"
+      app:popEnterAnim="@anim/slide_in_left"
+      app:popExitAnim="@anim/slide_out_right" />
   </fragment>
 </navigation>

--- a/android/app/src/main/res/values-land/dimens.xml
+++ b/android/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+  <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,16 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <!-- Base application theme. -->
+  <style name="Theme.BasicActivityApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <!-- Primary brand color. -->
+    <item name="colorPrimary">@color/purple_200</item>
+    <item name="colorPrimaryVariant">@color/purple_700</item>
+    <item name="colorOnPrimary">@color/black</item>
+    <!-- Secondary brand color. -->
+    <item name="colorSecondary">@color/teal_200</item>
+    <item name="colorSecondaryVariant">@color/teal_200</item>
+    <item name="colorOnSecondary">@color/black</item>
+    <!-- Status bar color. -->
+    <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+    <!-- Customize your theme here. -->
+  </style>
+</resources>

--- a/android/app/src/main/res/values-w1240dp/dimens.xml
+++ b/android/app/src/main/res/values-w1240dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+  <dimen name="fab_margin">200dp</dimen>
+</resources>

--- a/android/app/src/main/res/values-w600dp/dimens.xml
+++ b/android/app/src/main/res/values-w600dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+  <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="purple_200">#FFBB86FC</color>
+  <color name="purple_500">#FF6200EE</color>
+  <color name="purple_700">#FF3700B3</color>
+  <color name="teal_200">#FF03DAC5</color>
+  <color name="teal_700">#FF018786</color>
+  <color name="black">#FF000000</color>
+  <color name="white">#FFFFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+  <dimen name="fab_margin">16dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,12 @@
 <resources>
   <string name="app_name">AndroidStartupPerfApp</string>
+  <string name="action_settings">Settings</string>
+  <!-- Strings used for fragments for navigation -->
+  <string name="first_fragment_label">First Fragment</string>
+  <string name="second_fragment_label">Second Fragment</string>
+  <string name="next">Next</string>
+  <string name="previous">Previous</string>
+
+  <string name="hello_first_fragment">Hello first fragment</string>
+  <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,9 +4,11 @@
   <!-- Strings used for fragments for navigation -->
   <string name="first_fragment_label">First Fragment</string>
   <string name="second_fragment_label">Second Fragment</string>
+  <string name="third_fragment_label">Third Fragment</string>
   <string name="next">Next</string>
   <string name="previous">Previous</string>
 
   <string name="hello_first_fragment">Hello first fragment. This is native.</string>
   <string name="hello_second_fragment">Hello second fragment. This is still native!</string>
+  <string name="hello_third_fragment">Hello third fragment. One final native screen before launching React Native!</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,6 @@
   <string name="next">Next</string>
   <string name="previous">Previous</string>
 
-  <string name="hello_first_fragment">Hello first fragment</string>
-  <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
+  <string name="hello_first_fragment">Hello first fragment. This is native.</string>
+  <string name="hello_second_fragment">Hello second fragment. This is still native!</string>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,25 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <!-- Base application theme. -->
+  <style name="Theme.AndroidStartupPerfApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <!-- Primary brand color. -->
+    <item name="colorPrimary">@color/purple_500</item>
+    <item name="colorPrimaryVariant">@color/purple_700</item>
+    <item name="colorOnPrimary">@color/white</item>
+    <!-- Secondary brand color. -->
+    <item name="colorSecondary">@color/teal_200</item>
+    <item name="colorSecondaryVariant">@color/teal_700</item>
+    <item name="colorOnSecondary">@color/black</item>
+    <!-- Status bar color. -->
+    <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+    <!-- Customize your theme here. -->
+  </style>
+
+  <style name="Theme.AndroidStartupPerfApp.NoActionBar">
+    <item name="windowActionBar">false</item>
+    <item name="windowNoTitle">true</item>
+  </style>
+
+  <style name="Theme.AndroidStartupPerfApp.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+  <style name="Theme.AndroidStartupPerfApp.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+</resources>


### PR DESCRIPTION
## Summary
To investigate a possible means of shortening the perceived UI loading time during app startup in React Native, we'll introduce a native Android app which contains a very simple navigation implementation.

The purpose of this native implementation is to let the app load UI elements which are native to Android and keep the end user busy in the fully native screens while the much slower React Native loads in the background. These submitted changes don't introduce React Native yet. That effort will be reserved for peer review in another pull request.