### PR TITLE
feat(react): create Android detached custom React activity

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,6 +187,15 @@ android {
 
         }
     }
+
+    /**
+     * Android native class binding to XML view layouts.
+     * Used in referenced to: com.androidstartupperfapp.databinding
+     * This is required for navigation to work in Android native.
+     */
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -194,7 +203,15 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
+    // Seems like these are the last versions that will support API 30.
+    // - androidx.appcompat:appcompat:1.3.1
+    // - androidx.navigation:navigation-* 2.3.5
+    // Any further and the app won't compile.
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "androidx.navigation:navigation-fragment:2.3.5"
+    implementation "androidx.navigation:navigation-ui:2.3.5"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'
@@ -216,6 +233,17 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    // Tried 1.6.2, but receives this on compile time at minCompileSdk 30:
+    // AAPT: error: resource android:color/system_neutral1_1000 not found.
+    // Stick to 1.4.0 for now.
+    // https://stackoverflow.com/a/69065309/11455106
+    //
+    // So, what do we lose?
+    // Dynamic colors support using the newer theme API from Material 3 is
+    // practically nonexistent until Android S (a.k.a API 31).
+    // Until then, accent colors have to be applied directly on the layout.
+    implementation "com.google.android.material:material:1.4.0"
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,16 +10,25 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <!-- About "singleTop" -->
+      <!-- Allows the app to resume ReactActivity if it was the last one on the stack. -->
+      <!-- https://www.mobomo.com/2011/06/android-understanding-activity-launchmode -->
+      <!-- https://stackoverflow.com/questions/1450019/android-restore-last-viewed-activity#comment19114809_1450579 -->
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-        android:launchMode="singleTask"
+        android:launchMode="singleTop"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
           <action android:name="android.intent.action.MAIN" />
           <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+      </activity>
+      <activity
+        android:name=".ReactActivity"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
       </activity>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,8 +17,8 @@
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
     </application>

--- a/android/app/src/main/java/com/androidstartupperfapp/FirstFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/FirstFragment.java
@@ -1,0 +1,44 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import com.androidstartupperfapp.databinding.FirstFragmentBinding;
+
+public class FirstFragment extends Fragment {
+
+  private FirstFragmentBinding binding;
+
+  @Override
+  public View onCreateView(
+    LayoutInflater inflater, ViewGroup container,
+    Bundle savedInstanceState
+  ) {
+    binding = FirstFragmentBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    binding.firstButton.setOnClickListener(this::onFirstButtonClick);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+
+  private void onFirstButtonClick(View view) {
+    NavHostFragment
+      .findNavController(FirstFragment.this)
+      .navigate(R.id.action_FirstFragment_to_SecondFragment);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
@@ -1,15 +1,67 @@
 package com.androidstartupperfapp;
 
-import com.facebook.react.ReactActivity;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 
-public class MainActivity extends ReactActivity {
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import androidx.navigation.ui.AppBarConfiguration;
+import androidx.navigation.ui.NavigationUI;
 
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
+import com.androidstartupperfapp.databinding.MainActivityBinding;
+import com.google.android.material.snackbar.Snackbar;
+
+public class MainActivity extends AppCompatActivity {
+
+  private AppBarConfiguration appBarConfiguration;
+  private MainActivityBinding binding;
+
   @Override
-  protected String getMainComponentName() {
-    return "AndroidStartupPerfApp";
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    binding = MainActivityBinding.inflate(getLayoutInflater());
+    setContentView(binding.getRoot());
+
+    setSupportActionBar(binding.toolbar);
+
+    NavController navController = Navigation.findNavController(this, R.id.nav_host_main_content_fragment);
+    appBarConfiguration = new AppBarConfiguration.Builder(navController.getGraph()).build();
+    NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+
+    binding.fab
+      .setOnClickListener(view -> Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
+      .setAction("Action", null).show());
+  }
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // Handle action bar item clicks here. The action bar will
+    // automatically handle clicks on the Home/Up button, so long
+    // as you specify a parent activity in AndroidManifest.xml.
+    int id = item.getItemId();
+
+    //noinspection SimplifiableIfStatement
+    if (id == R.id.action_settings) {
+      return true;
+    }
+
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    NavController navController = Navigation.findNavController(this, R.id.nav_host_main_content_fragment);
+    return NavigationUI.navigateUp(navController, appBarConfiguration)
+      || super.onSupportNavigateUp();
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
@@ -20,7 +20,11 @@ public class MainActivity extends AppCompatActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    // React Native Screens and React Navigation suggest using `null` for savedInstanceState.
+    // This supposedly prevents "persisted view state" inconsistency errors during activity restarts.
+    // https://github.com/software-mansion/react-native-screens#android
+    // https://reactnavigation.org/docs/getting-started#installing-dependencies-into-a-bare-react-native-project
+    super.onCreate(null);
 
     binding = MainActivityBinding.inflate(getLayoutInflater());
     setContentView(binding.getRoot());

--- a/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
@@ -1,80 +1,10 @@
 package com.androidstartupperfapp;
 
 import android.app.Application;
-import android.content.Context;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.soloader.SoLoader;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
-
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
-          return packages;
-        }
-
-        @Override
-        protected String getJSMainModuleName() {
-          return "index";
-        }
-      };
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
+public class MainApplication extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
-    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-
-  /**
-   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
-   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-   *
-   * @param context
-   * @param reactInstanceManager
-   */
-  private static void initializeFlipper(
-      Context context, ReactInstanceManager reactInstanceManager) {
-    if (BuildConfig.DEBUG) {
-      try {
-        /*
-         We use reflection here to pick up the class that initializes Flipper,
-        since Flipper library is not available in release mode
-        */
-        Class<?> aClass = Class.forName("com.androidstartupperfapp.ReactNativeFlipper");
-        aClass
-            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
-            .invoke(null, context, reactInstanceManager);
-      } catch (ClassNotFoundException e) {
-        e.printStackTrace();
-      } catch (NoSuchMethodException e) {
-        e.printStackTrace();
-      } catch (IllegalAccessException e) {
-        e.printStackTrace();
-      } catch (InvocationTargetException e) {
-        e.printStackTrace();
-      }
-    }
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/ReactActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/ReactActivity.java
@@ -1,0 +1,112 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.KeyEvent;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.ReactRootView;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.soloader.SoLoader;
+
+import java.util.List;
+
+// If you don't extend AppCompatActivity like React Native's real ReactActivity (e.g. using Activity
+// instead), React Native will crash, asking you to extend ReactActivity first.
+public class ReactActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
+
+  private ReactRootView mReactRootView;
+  private ReactInstanceManager mReactInstanceManager;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // React Native Screens and React Navigation suggest using `null` for savedInstanceState.
+    // This supposedly prevents "persisted view state" inconsistency errors during activity restarts.
+    // https://github.com/software-mansion/react-native-screens#android
+    // https://reactnavigation.org/docs/getting-started#installing-dependencies-into-a-bare-react-native-project
+    super.onCreate(null);
+    SoLoader.init(this, false);
+
+    mReactRootView = new ReactRootView(this);
+    List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
+    // Remember to include them in `settings.gradle` and `app/build.gradle` too.
+
+    mReactInstanceManager = ReactInstanceManager.builder()
+      .setApplication(getApplication())
+      .setCurrentActivity(this)
+      .setBundleAssetName("index.android.bundle")
+      .setJSMainModulePath("index")
+      .addPackages(packages)
+      .setUseDeveloperSupport(BuildConfig.DEBUG)
+      .setInitialLifecycleState(LifecycleState.RESUMED)
+      .build();
+    // The string here (e.g. "AndroidStartupPerfApp") has to match
+    // the string in AppRegistry.registerComponent() in index.js
+    mReactRootView.startReactApplication(mReactInstanceManager, "AndroidStartupPerfApp", null);
+
+    setContentView(mReactRootView);
+  }
+
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    super.onBackPressed();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostPause(this);
+    }
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostResume(this, this);
+    }
+  }
+
+  // Without android:launchMode="singleTop", the app will always call ReactActivity.onDestroy()
+  // before it calls MainActivity.onResume(), thus preventing the user from continuing work in
+  // this activity.
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostDestroy(this);
+    }
+    if (mReactRootView != null) {
+      mReactRootView.unmountReactApplication();
+    }
+  }
+
+  @Override
+  public void onBackPressed() {
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onBackPressed();
+    } else {
+      super.onBackPressed();
+    }
+  }
+
+  @Override
+  public boolean onKeyUp(int keyCode, KeyEvent event) {
+    if (keyCode == KeyEvent.KEYCODE_MENU && mReactInstanceManager != null) {
+      mReactInstanceManager.showDevOptionsDialog();
+      return true;
+    }
+
+    return super.onKeyUp(keyCode, event);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
@@ -1,0 +1,44 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import com.androidstartupperfapp.databinding.SecondFragmentBinding;
+
+public class SecondFragment extends Fragment {
+
+  private SecondFragmentBinding binding;
+
+  @Override
+  public View onCreateView(
+    LayoutInflater inflater, ViewGroup container,
+    Bundle savedInstanceState
+  ) {
+    binding = SecondFragmentBinding.inflate(inflater, container, false);
+    return binding.getRoot();
+  }
+
+  public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    binding.secondButton.setOnClickListener(this::onSecondButtonClick);
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    binding = null;
+  }
+
+  private void onSecondButtonClick(View view) {
+    NavHostFragment
+      .findNavController(SecondFragment.this)
+      .navigate(R.id.action_SecondFragment_to_FirstFragment);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/SecondFragment.java
@@ -1,5 +1,6 @@
 package com.androidstartupperfapp;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,6 +29,7 @@ public class SecondFragment extends Fragment {
     super.onViewCreated(view, savedInstanceState);
 
     binding.secondButton.setOnClickListener(this::onSecondButtonClick);
+    binding.startReactActivityButton.setOnClickListener(this::onStartReactActivityButtonClick);
   }
 
   @Override
@@ -40,5 +42,13 @@ public class SecondFragment extends Fragment {
     NavHostFragment
       .findNavController(SecondFragment.this)
       .navigate(R.id.action_SecondFragment_to_FirstFragment);
+  }
+
+  private void onStartReactActivityButtonClick(View view) {
+    // In a fragment, we can't use the current activity (MainActivity) class directly.
+    // However, we can use getActivity() to get the job done.
+    // https://stackoverflow.com/a/15478468/11455106
+    Intent intent = new Intent(getActivity(), ReactActivity.class);
+    startActivity(intent);
   }
 }

--- a/android/app/src/main/res/anim/slide_in_left.xml
+++ b/android/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/linear_interpolator">
+    <translate
+        android:duration="500"
+        android:fromXDelta="100%"
+        android:fromYDelta="0%"
+        android:toXDelta="0%"
+        android:toYDelta="0%" />
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:duration="300" />
+</set>

--- a/android/app/src/main/res/anim/slide_in_right.xml
+++ b/android/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/linear_interpolator">
+    <translate
+        android:duration="500"
+        android:fromXDelta="50%"
+        android:fromYDelta="0%"
+        android:toXDelta="0%"
+        android:toYDelta="0%" />
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:duration="300" />
+</set>

--- a/android/app/src/main/res/anim/slide_out_left.xml
+++ b/android/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/linear_interpolator">
+    <translate
+        android:duration="500"
+        android:fromXDelta="100%"
+        android:fromYDelta="0%"
+        android:toXDelta="0%"
+        android:toYDelta="0%" />
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:duration="300" />
+</set>

--- a/android/app/src/main/res/anim/slide_out_right.xml
+++ b/android/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/linear_interpolator">
+    <translate
+        android:duration="500"
+        android:fromXDelta="50%"
+        android:fromYDelta="0%"
+        android:toXDelta="0%"
+        android:toYDelta="0%" />
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:duration="300" />
+</set>

--- a/android/app/src/main/res/layout/first_fragment.xml
+++ b/android/app/src/main/res/layout/first_fragment.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FirstFragment">
+
+    <TextView
+        android:id="@+id/first_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hello_first_fragment"
+        app:layout_constraintBottom_toTopOf="@id/first_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+    android:id="@+id/first_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:backgroundTint="@color/purple_500"
+    android:text="@string/next"
+    android:textColor="@color/white"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/first_textview" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/main_activity.xml
+++ b/android/app/src/main/res/layout/main_activity.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Theme.AndroidStartupPerfApp.AppBarOverlay">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/purple_500"
+        app:popupTheme="@style/Theme.AndroidStartupPerfApp.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include layout="@layout/main_content" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginBottom="16dp"
+        app:srcCompat="@android:drawable/ic_dialog_email" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/main_content.xml
+++ b/android/app/src/main/res/layout/main_content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <fragment
+        android:id="@+id/nav_host_main_content_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -10,6 +10,7 @@
         android:id="@+id/second_textview"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/hello_second_fragment"
         app:layout_constraintBottom_toTopOf="@id/second_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SecondFragment">
+
+    <TextView
+        android:id="@+id/second_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/second_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/second_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/purple_500"
+        android:text="@string/previous"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_textview" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -27,4 +27,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/second_textview" />
+
+    <Button
+        android:id="@+id/start_react_activity_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/teal_700"
+        android:text="@string/start_react_activity"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.csantarin.basicactivityapp.MainActivity">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:title="@string/action_settings"
+        app:showAsAction="never" />
+</menu>

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/FirstFragment">
+
+    <fragment
+        android:id="@+id/FirstFragment"
+        android:name="com.androidstartupperfapp.FirstFragment"
+        android:label="@string/first_fragment_label"
+        tools:layout="@layout/first_fragment">
+
+        <action
+            android:id="@+id/action_FirstFragment_to_SecondFragment"
+            app:destination="@id/SecondFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
+    <fragment
+        android:id="@+id/SecondFragment"
+        android:name="com.androidstartupperfapp.SecondFragment"
+        android:label="@string/second_fragment_label"
+        tools:layout="@layout/second_fragment">
+
+        <action
+            android:id="@+id/action_SecondFragment_to_FirstFragment"
+            app:destination="@id/FirstFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
+</navigation>

--- a/android/app/src/main/res/values-land/dimens.xml
+++ b/android/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,16 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Base application theme. -->
+    <style name="Theme.BasicActivityApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_200</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/black</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_200</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/android/app/src/main/res/values-w1240dp/dimens.xml
+++ b/android/app/src/main/res/values-w1240dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">200dp</dimen>
+</resources>

--- a/android/app/src/main/res/values-w600dp/dimens.xml
+++ b/android/app/src/main/res/values-w600dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">16dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,6 @@
     <string name="next">Next</string>
     <string name="previous">Previous</string>
 
-    <string name="hello_first_fragment">Hello first fragment</string>
-    <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
+    <string name="hello_first_fragment">Hello first fragment. This is native.</string>
+    <string name="hello_second_fragment">Hello second fragment. This is still native!</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="second_fragment_label">Second Fragment</string>
     <string name="next">Next</string>
     <string name="previous">Previous</string>
+    <string name="start_react_activity">Start React Activity</string>
 
     <string name="hello_first_fragment">Hello first fragment. This is native.</string>
     <string name="hello_second_fragment">Hello second fragment. This is still native!</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,12 @@
 <resources>
     <string name="app_name">AndroidStartupPerfApp</string>
+    <string name="action_settings">Settings</string>
+    <!-- Strings used for fragments for navigation -->
+    <string name="first_fragment_label">First Fragment</string>
+    <string name="second_fragment_label">Second Fragment</string>
+    <string name="next">Next</string>
+    <string name="previous">Previous</string>
+
+    <string name="hello_first_fragment">Hello first fragment</string>
+    <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,25 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Base application theme. -->
+    <style name="Theme.AndroidStartupPerfApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <!-- Customize your theme here. -->
+    </style>
+
+    <style name="Theme.AndroidStartupPerfApp.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Theme.AndroidStartupPerfApp.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="Theme.AndroidStartupPerfApp.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+</resources>


### PR DESCRIPTION
## Summary
Starting point: #11

React Native is launched as a separate activity from native Android. This done by implementing a separate activity that tries to imitate as much React activity behavior as is required in order to perform basic React Native operations such as root view unmounting, back button navigation, view host lifecycles, ...

**NOTE:** This integration makes the assumption that the native stack feature of React Navigation exists as a critical dependency for developer's productivity in client code for custom screens in React Native.

https://user-images.githubusercontent.com/67677362/197924303-87f5402c-4380-49c7-a5a2-ab6b1be03d53.mp4

## Notable findings

1. ### Subclassing `Activity` instead of `AppCompatActivity` crashes React Navigation.

    <details>
    <summary>Finding</summary>
    
    When subclassing `Activity`, as suggested in the React Native docs, the app will stop functioning once the end user attempts to launch the React activity portion of the app.
    
    It's possible that React Native Screens expects the behaviors that exist in `AppCompatActivity` which don't exist in `Activity`.
    </details>

2. ### Using `singleTask` as the `launchMode` prevents custom `ReactActivity` from warm starting.

    <details>
    <summary>Finding</summary>
    
    While the default `singleTask` setting from the React Native boilerplate does work, it will always cause the app to resume at the `MainActivity` instead. In that situation, the `ReactActivity.onDestroy()` method was called before `MainActivity.onResume()`.
    
    Setting to `singleTop` changes this behavior somewhat: when the app is restored from the background (it hasn't been killed yet), Android selects the last activity from the app's native stack and resumes from there, thus preserving the activity last viewed by the user. In this case, that last activity should be the custom `ReactActivity`.
    
    The consequences of changing the `launchMode` especially on 3rd-party SDKs is still unknown.
    </details>

3. ### Loading `ReactRootView` on demand introduces a noticeable delay every time custom `ReactActivity` is started.

    <details>
    <summary>Finding</summary>
    
    This approach causes the bundle to always perform a bundle load at app launch, which adds a small moment of delay to UI readiness, thus worsening the perceived loading duration.
    
    No analysis yet.
    
    </details>

## References
- https://reactnative.dev/docs/integration-with-existing-apps
