### PR TITLE
refactor(app): elevate NavigationContainer to root

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@
  * @format
  */
 
+import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
 
 import Flow from './flow/ui/Flow';
@@ -15,9 +16,10 @@ import Flow from './flow/ui/Flow';
 export const APP_NAME = 'AndroidStartupPerfApp';
 
 const App = () => {
-  // eslint-disable-next-line prettier/prettier
   return (
-    <Flow />
+    <NavigationContainer>
+      <Flow />
+    </NavigationContainer>
   );
 };
 

--- a/src/flow/ui/Flow.tsx
+++ b/src/flow/ui/Flow.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
 
 import FlowStack from '../nav/FlowStack';
@@ -12,20 +11,18 @@ const Flow = () => {
 
   return (
     <FlowStateContext.Provider value={flowDataStateContextValue}>
-      <NavigationContainer>
-        <FlowStack.Navigator initialRouteName={INITIAL_FLOW_STACK_SCREEN_ROUTE}>
-          {FLOW_STACK_SCREEN_ROUTES.map((route) => {
-            const screen = FLOW_STACK_SCREENS[route];
-            return (
-              <FlowStack.Screen
-                key={route}
-                name={route} // e.g. "Step1"
-                component={screen} // e.g. Step1Screen
-              />
-            );
-          })}
-        </FlowStack.Navigator>
-      </NavigationContainer>
+      <FlowStack.Navigator initialRouteName={INITIAL_FLOW_STACK_SCREEN_ROUTE}>
+        {FLOW_STACK_SCREEN_ROUTES.map((route) => {
+          const screen = FLOW_STACK_SCREENS[route];
+          return (
+            <FlowStack.Screen
+              key={route}
+              name={route} // e.g. "Step1"
+              component={screen} // e.g. Step1Screen
+            />
+          );
+        })}
+      </FlowStack.Navigator>
     </FlowStateContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
There might be a need to use `<NavigationContainer />` at a level where it doesn't have to know what the routes at the lower levels look like. The only con I can think of is the increase of scope of routes the the `NavigationContainer` must know. This is quite fine, as no special routing behaviors have to be introduced at this point.
