### PR TITLE
feat(modal): demo example

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,11 +12,21 @@ import { NavigationContainer, NavigationState } from '@react-navigation/native';
 import React from 'react';
 
 import Flow from './flow/ui/Flow';
+import Modal from './modal/ui/Modal';
 import NavigationStateStore from './navigation/NavigationStateStore';
 
 export const APP_NAME = 'AndroidStartupPerfApp';
 
 const App = () => {
+  const showModalOnly: boolean = false;
+
+  if (showModalOnly) {
+    // eslint-disable-next-line prettier/prettier
+    return (
+      <Modal />
+    );
+  }
+
   /**
    * Respond to the state change by syncing the current back stack store in native code up with
    * whatever back stack index this container is at.

--- a/src/flow/ui/screens/HomeScreen.tsx
+++ b/src/flow/ui/screens/HomeScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Text } from 'react-native';
 
 import ScreenView from '../../../components/ScreenView';
+import ModalDemo from '../../../modal/ui/ModalDemo';
 
 import useFlowStackNavigatorNavigate from '../../nav/useFlowStackNavigatorNavigate';
 
@@ -12,6 +13,7 @@ const HomeScreen = () => {
     <ScreenView>
       <Text>Home</Text>
       <Button title="Start" onPress={navigateTo.Step1} />
+      <ModalDemo />
     </ScreenView>
   );
 };

--- a/src/modal/ui/Modal.tsx
+++ b/src/modal/ui/Modal.tsx
@@ -1,0 +1,3 @@
+import ModalDemoScreen from './ModalDemoScreen';
+
+export default ModalDemoScreen;

--- a/src/modal/ui/ModalDemo.tsx
+++ b/src/modal/ui/ModalDemo.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { Alert, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+
+const ModalDemo = () => {
+  const [modalVisible, setModalVisible] = useState(false);
+  const handleModalRequestClose = () => {
+    Alert.alert('Modal has been closed.');
+    setModalVisible(!modalVisible);
+  };
+  const handleModalHideButtonPress = () => {
+    setModalVisible(!modalVisible);
+  };
+  const handleModalShowButtonPress = () => {
+    setModalVisible(true);
+  };
+
+  return (
+    <View style={styles.centeredView}>
+      <Modal
+        // multiline
+        animationType="slide"
+        transparent={true}
+        visible={modalVisible}
+        onRequestClose={handleModalRequestClose}
+      >
+        <View style={styles.centeredView}>
+          <View style={styles.modalView}>
+            <Text style={styles.modalText}>Hello World!</Text>
+            <Pressable
+              // multiline
+              style={[styles.button, styles.buttonClose]}
+              onPress={handleModalHideButtonPress}
+            >
+              <Text style={styles.textStyle}>Hide Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+      <Pressable
+        // multiline
+        style={[styles.button, styles.buttonOpen]}
+        onPress={handleModalShowButtonPress}
+      >
+        <Text style={styles.textStyle}>Show Modal</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  modalView: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  button: {
+    borderRadius: 20,
+    padding: 10,
+    elevation: 2,
+  },
+  buttonOpen: {
+    backgroundColor: '#F194FF',
+  },
+  buttonClose: {
+    backgroundColor: '#2196F3',
+  },
+  textStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  modalText: {
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+});
+
+export default ModalDemo;

--- a/src/modal/ui/ModalDemo.tsx
+++ b/src/modal/ui/ModalDemo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Button, Modal, StyleSheet, Text, View } from 'react-native';
 
 const ModalDemo = () => {
   const [modalVisible, setModalVisible] = useState(false);
@@ -15,7 +15,7 @@ const ModalDemo = () => {
   };
 
   return (
-    <View style={styles.centeredView}>
+    <>
       <Modal
         // multiline
         animationType="slide"
@@ -26,26 +26,26 @@ const ModalDemo = () => {
         <View style={styles.centeredView}>
           <View style={styles.modalView}>
             <Text style={styles.modalText}>Hello World!</Text>
-            <Pressable
+            <Button
               // multiline
-              style={[styles.button, styles.buttonClose]}
+              color={BUTTON_COLOR}
+              title="Hide Modal"
               onPress={handleModalHideButtonPress}
-            >
-              <Text style={styles.textStyle}>Hide Modal</Text>
-            </Pressable>
+            />
           </View>
         </View>
       </Modal>
-      <Pressable
+      <Button
         // multiline
-        style={[styles.button, styles.buttonOpen]}
+        color={BUTTON_COLOR}
+        title="Show Modal"
         onPress={handleModalShowButtonPress}
-      >
-        <Text style={styles.textStyle}>Show Modal</Text>
-      </Pressable>
-    </View>
+      />
+    </>
   );
 };
+
+const BUTTON_COLOR = '#03DAC5';
 
 const styles = StyleSheet.create({
   centeredView: {
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
   modalView: {
     margin: 20,
     backgroundColor: 'white',
-    borderRadius: 20,
+    borderRadius: 8,
     padding: 35,
     alignItems: 'center',
     shadowColor: '#000',
@@ -68,17 +68,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 4,
     elevation: 5,
-  },
-  button: {
-    borderRadius: 20,
-    padding: 10,
-    elevation: 2,
-  },
-  buttonOpen: {
-    backgroundColor: '#F194FF',
-  },
-  buttonClose: {
-    backgroundColor: '#2196F3',
   },
   textStyle: {
     color: 'white',

--- a/src/modal/ui/ModalDemo.tsx
+++ b/src/modal/ui/ModalDemo.tsx
@@ -4,7 +4,7 @@ import { Alert, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 const ModalDemo = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const handleModalRequestClose = () => {
-    Alert.alert('Modal has been closed.');
+    Alert.alert('Modal has been closed via hardware back button.');
     setModalVisible(!modalVisible);
   };
   const handleModalHideButtonPress = () => {

--- a/src/modal/ui/ModalDemoScreen.tsx
+++ b/src/modal/ui/ModalDemoScreen.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import ModalDemo from './ModalDemo';
+
+const ModalDemoScreen = () => {
+  return (
+    <View style={[styles.centeredView, styles.whiteView]}>
+      <ModalDemo />
+    </View>
+  );
+};
+
+ModalDemoScreen.ROUTE = 'ModalDemo' as const;
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  whiteView: {
+    backgroundColor: 'white',
+  },
+});
+
+export default ModalDemoScreen;


### PR DESCRIPTION
## Summary
To explore and demonstrate the feasibility of using modals in unconventional React Native setup. The intention is to prove that regardless of whether the modal is in a route or not, or whether the back button is pressed or not, the React portion of the app still works without crashing.
