### PR TITLE
feat(tti): embed React root view as Android fragment in non-conventional setup

### DIFF
--- a/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
@@ -3,6 +3,7 @@ package com.androidstartupperfapp;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.navigation.NavController;
@@ -11,9 +12,13 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.androidstartupperfapp.databinding.MainActivityBinding;
+import com.androidstartupperfapp.navigation.NavigationStateStore;
+import com.androidstartupperfapp.react.ReactFragmentInstanceManager;
+import com.facebook.react.ReactFragment;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.google.android.material.snackbar.Snackbar;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
 
   private AppBarConfiguration appBarConfiguration;
   private MainActivityBinding binding;
@@ -34,6 +39,9 @@ public class MainActivity extends AppCompatActivity {
     binding.fab
       .setOnClickListener(view -> Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
       .setAction("Action", null).show());
+
+    ReactFragmentInstanceManager.setFragmentManager(getSupportFragmentManager());
+    ReactFragmentInstanceManager.loadReactFragment();
   }
 
   @Override
@@ -63,5 +71,25 @@ public class MainActivity extends AppCompatActivity {
     NavController navController = Navigation.findNavController(this, R.id.nav_host_main_content_fragment);
     return NavigationUI.navigateUp(navController, appBarConfiguration)
       || super.onSupportNavigateUp();
+  }
+
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    super.onBackPressed();
+  }
+
+  @Override
+  public void onBackPressed() {
+    ReactFragment reactFragment = ReactFragmentInstanceManager.getReactFragment();
+
+    if (reactFragment.isVisible()) {
+      if (NavigationStateStore.getIndex() > 0) {
+        reactFragment.onBackPressed();
+      } else {
+        ReactFragmentInstanceManager.hideReactFragment();
+      }
+    } else {
+      super.onBackPressed();
+    }
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
@@ -1,10 +1,78 @@
 package com.androidstartupperfapp;
 
 import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 
-public class MainApplication extends Application {
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    @Override
+    public boolean getUseDeveloperSupport() {
+      return BuildConfig.DEBUG;
+    }
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      return packages;
+    }
+
+    @Override
+    protected String getJSMainModuleName() {
+      return "index";
+    }
+  };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
   @Override
   public void onCreate() {
     super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    MainApplication.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.androidstartupperfapp.ReactNativeFlipper");
+        aClass
+          .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+          .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
   }
 }

--- a/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainApplication.java
@@ -2,6 +2,8 @@ package com.androidstartupperfapp;
 
 import android.app.Application;
 import android.content.Context;
+
+import com.androidstartupperfapp.navigation.RNNavigationStateStorePackage;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -25,6 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       // Packages that cannot be autolinked yet can be added manually here, for example:
       // packages.add(new MyReactNativePackage());
+      packages.add(new RNNavigationStateStorePackage());
       return packages;
     }
 

--- a/android/app/src/main/java/com/androidstartupperfapp/navigation/NavigationStateStore.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/navigation/NavigationStateStore.java
@@ -1,0 +1,14 @@
+package com.androidstartupperfapp.navigation;
+
+public final class NavigationStateStore {
+
+  private static int index = 0;
+
+  public static int getIndex() {
+    return index;
+  }
+
+  public static void setIndex(int index) {
+    NavigationStateStore.index = index;
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/navigation/RNNavigationStateStoreModule.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/navigation/RNNavigationStateStoreModule.java
@@ -1,0 +1,25 @@
+package com.androidstartupperfapp.navigation;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class RNNavigationStateStoreModule extends ReactContextBaseJavaModule {
+
+  public RNNavigationStateStoreModule(ReactApplicationContext context) {
+    super(context);
+  }
+
+  @NonNull
+  @Override
+  public String getName() {
+    return "RNNavigationStateStore";
+  }
+
+  @ReactMethod
+  public void setIndex(int index) {
+    NavigationStateStore.setIndex(index);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/navigation/RNNavigationStateStorePackage.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/navigation/RNNavigationStateStorePackage.java
@@ -1,0 +1,28 @@
+package com.androidstartupperfapp.navigation;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RNNavigationStateStorePackage implements ReactPackage {
+
+  @NonNull
+  @Override
+  public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new RNNavigationStateStoreModule(reactContext));
+    return modules;
+  }
+
+  @NonNull
+  @Override
+  public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+    return new ArrayList<>();
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/react/ReactFragmentInstanceManager.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/react/ReactFragmentInstanceManager.java
@@ -1,0 +1,50 @@
+package com.androidstartupperfapp.react;
+
+import androidx.annotation.IdRes;
+import androidx.fragment.app.FragmentManager;
+
+import com.androidstartupperfapp.R;
+import com.facebook.react.ReactFragment;
+
+public final class ReactFragmentInstanceManager {
+  private static ReactFragment reactFragment;
+  private static FragmentManager fragmentManager;
+  @IdRes
+  private final static int reactFragmentId = R.id.react_fragment;
+  private final static String componentName = "AndroidStartupPerfApp";
+
+  public static void setFragmentManager(FragmentManager fragmentManager) {
+    ReactFragmentInstanceManager.fragmentManager = fragmentManager;
+  }
+
+  public static ReactFragment getReactFragment() {
+    return reactFragment;
+  }
+
+  public static void loadReactFragment() {
+    reactFragment = new ReactFragment.Builder()
+      .setComponentName(componentName)
+      .build();
+
+    fragmentManager
+      .beginTransaction()
+      .add(reactFragmentId, reactFragment)
+      .addToBackStack(componentName)
+      .hide(reactFragment)
+      .commit();
+  }
+
+  public static void hideReactFragment() {
+    fragmentManager
+      .beginTransaction()
+      .hide(reactFragment)
+      .commit();
+  }
+
+  public static void showReactFragment() {
+    fragmentManager
+      .beginTransaction()
+      .show(reactFragment)
+      .commit();
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/ThirdFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/ThirdFragment.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.androidstartupperfapp.databinding.ThirdFragmentBinding;
+import com.androidstartupperfapp.react.ReactFragmentInstanceManager;
 
 public class ThirdFragment extends Fragment {
 
@@ -27,11 +28,17 @@ public class ThirdFragment extends Fragment {
   @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
+
+    binding.showReactFragmentButton.setOnClickListener(this::onShowReactFragmentButtonClick);
   }
 
   @Override
   public void onDestroyView() {
     super.onDestroyView();
     binding = null;
+  }
+
+  private void onShowReactFragmentButtonClick(View view) {
+    ReactFragmentInstanceManager.showReactFragment();
   }
 }

--- a/android/app/src/main/res/layout/main_activity.xml
+++ b/android/app/src/main/res/layout/main_activity.xml
@@ -22,6 +22,11 @@
 
   <include layout="@layout/main_content" />
 
+  <FrameLayout
+    android:id="@+id/react_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fab"
     android:layout_width="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
   <string name="third_fragment_label">Third Fragment</string>
   <string name="next">Next</string>
   <string name="previous">Previous</string>
+  <string name="show_react_fragment">Show React Fragment</string>
 
   <string name="hello_first_fragment">Hello first fragment. This is native.</string>
   <string name="hello_second_fragment">Hello second fragment. This is still native!</string>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,16 +8,28 @@
  * @format
  */
 
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, NavigationState } from '@react-navigation/native';
 import React from 'react';
 
 import Flow from './flow/ui/Flow';
+import NavigationStateStore from './navigation/NavigationStateStore';
 
 export const APP_NAME = 'AndroidStartupPerfApp';
 
 const App = () => {
+  /**
+   * Respond to the state change by syncing the current back stack store in native code up with
+   * whatever back stack index this container is at.
+   * @param state The current navigation state.
+   */
+  // There's an option to also narrow the `state.routes` down specifically to the flow navigation
+  // tree, but we don't need it, so we're not applying `FlowStackParamList` to the generic type.
+  const handleNavigationContainerStateChange = (state: NavigationState | undefined) => {
+    NavigationStateStore.setIndex(state?.index);
+  };
+
   return (
-    <NavigationContainer>
+    <NavigationContainer onStateChange={handleNavigationContainerStateChange}>
       <Flow />
     </NavigationContainer>
   );

--- a/src/navigation/NavigationStateStore.ts
+++ b/src/navigation/NavigationStateStore.ts
@@ -1,0 +1,36 @@
+import { NativeModules, Platform } from 'react-native';
+
+const { RNNavigationStateStore } = NativeModules as typeof NativeModules & {
+  RNNavigationStateStore: RNNavigationStateStore;
+};
+
+interface RNNavigationStateStore {
+  setIndex: (index: number) => void;
+}
+
+class NavigationStateStore {
+  /**
+   * Stores the current back stack index of React Navigation's navigation container **on Android only**.
+   *
+   * By itself, this bridge method does absolutely nothing — all it does is to store a value passed by
+   * the calling function. The value needs to be read and evaluated elsewhere natively.
+   *
+   * To put it to good use, consume this in conjunction with back button handling at the implementation
+   * of Android's native `AppCompatActivity.onBackPressed()`.
+   * @param index The current back stack value of `<NavigationContainer>`. If it's `null`-ish, the store doesn't update.
+   * @returns
+   */
+  public setIndex(index?: number | null) {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+
+    if (index == null) {
+      return;
+    }
+
+    RNNavigationStateStore.setIndex(index);
+  }
+}
+
+export default new NavigationStateStore();


### PR DESCRIPTION
## Summary
Starting point: #23

Previously in #25 (a.k.a. #12), we discovered the design shortcomings of using a custom React activity, separate from the main Android activity, to run React Native which must host the React Native root view (and, consequently, the React Native fragment), where:
1. We must maintain the JavaScript bundle loading on demand only when the custom React activity is launched, therefore, delaying the inevitable: slow React Native TTI.
2. We must work around the JavaScript bundle loading on demand by reimplementing much of the React Native architecture such that the main Android activity and the custom React activity — reengineering strays far from the beaten path and is impractical to achieve with limited resources.

This approach works around the custom React activity problem by embedding React Native into the main Android activity as a fragment, allowing React Native to defer to the main Android activity as its host.

In this approach, React Native is loaded in the background while hidden. In this phase, the end user is presented with a limited set of native Android screens to keep the end user occupied while the JavaScript bundle is being parsed and executed for React app initialization. The React Native view, which would be fully loaded and immediately ready for work at this point, remains in that state until the end user has decided to launch the React app portion of the Android app, thus giving the end user the illusion of a very fast TTI.

## References
- https://reactnative.dev/docs/integration-with-android-fragment
