### PR TITLE
feat(tti): embed React root view as Android activity in non-conventional setup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,16 +10,25 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:theme="@style/AppTheme">
+    <!-- About "singleTop" -->
+    <!-- Allows the app to resume ReactActivity if it was the last one on the stack. -->
+    <!-- https://www.mobomo.com/2011/06/android-understanding-activity-launchmode -->
+    <!-- https://stackoverflow.com/questions/1450019/android-restore-last-viewed-activity#comment19114809_1450579 -->
     <activity
       android:name=".MainActivity"
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
       android:label="@string/app_name"
-      android:launchMode="singleTask"
+      android:launchMode="singleTop"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+    </activity>
+    <activity
+      android:name=".ReactActivity"
+      android:label="@string/app_name"
+      android:theme="@style/Theme.AppCompat.Light.NoActionBar">
     </activity>
   </application>
 </manifest>

--- a/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/MainActivity.java
@@ -20,7 +20,11 @@ public class MainActivity extends AppCompatActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    // React Native Screens and React Navigation suggest using `null` for savedInstanceState.
+    // This supposedly prevents "persisted view state" inconsistency errors during activity restarts.
+    // https://github.com/software-mansion/react-native-screens#android
+    // https://reactnavigation.org/docs/getting-started#installing-dependencies-into-a-bare-react-native-project
+    super.onCreate(null);
 
     binding = MainActivityBinding.inflate(getLayoutInflater());
     setContentView(binding.getRoot());

--- a/android/app/src/main/java/com/androidstartupperfapp/ReactActivity.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/ReactActivity.java
@@ -1,0 +1,112 @@
+package com.androidstartupperfapp;
+
+import android.os.Bundle;
+import android.view.KeyEvent;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.ReactRootView;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.soloader.SoLoader;
+
+import java.util.List;
+
+// If you don't extend AppCompatActivity like React Native's real ReactActivity (e.g. using Activity
+// instead), React Native will crash, asking you to extend ReactActivity first.
+public class ReactActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
+
+  private ReactRootView mReactRootView;
+  private ReactInstanceManager mReactInstanceManager;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // React Native Screens and React Navigation suggest using `null` for savedInstanceState.
+    // This supposedly prevents "persisted view state" inconsistency errors during activity restarts.
+    // https://github.com/software-mansion/react-native-screens#android
+    // https://reactnavigation.org/docs/getting-started#installing-dependencies-into-a-bare-react-native-project
+    super.onCreate(null);
+    SoLoader.init(this, false);
+
+    mReactRootView = new ReactRootView(this);
+    List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
+    // Remember to include them in `settings.gradle` and `app/build.gradle` too.
+
+    mReactInstanceManager = ReactInstanceManager.builder()
+      .setApplication(getApplication())
+      .setCurrentActivity(this)
+      .setBundleAssetName("index.android.bundle")
+      .setJSMainModulePath("index")
+      .addPackages(packages)
+      .setUseDeveloperSupport(BuildConfig.DEBUG)
+      .setInitialLifecycleState(LifecycleState.RESUMED)
+      .build();
+    // The string here (e.g. "AndroidStartupPerfApp") has to match
+    // the string in AppRegistry.registerComponent() in index.js
+    mReactRootView.startReactApplication(mReactInstanceManager, "AndroidStartupPerfApp", null);
+
+    setContentView(mReactRootView);
+  }
+
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    super.onBackPressed();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostPause(this);
+    }
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostResume(this, this);
+    }
+  }
+
+  // Without android:launchMode="singleTop", the app will always call ReactActivity.onDestroy()
+  // before it calls MainActivity.onResume(), thus preventing the user from continuing work in
+  // this activity.
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onHostDestroy(this);
+    }
+    if (mReactRootView != null) {
+      mReactRootView.unmountReactApplication();
+    }
+  }
+
+  @Override
+  public void onBackPressed() {
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onBackPressed();
+    } else {
+      super.onBackPressed();
+    }
+  }
+
+  @Override
+  public boolean onKeyUp(int keyCode, KeyEvent event) {
+    if (keyCode == KeyEvent.KEYCODE_MENU && mReactInstanceManager != null) {
+      mReactInstanceManager.showDevOptionsDialog();
+      return true;
+    }
+
+    return super.onKeyUp(keyCode, event);
+  }
+}

--- a/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
+++ b/android/app/src/main/java/com/androidstartupperfapp/screens/SecondFragment.java
@@ -1,5 +1,6 @@
 package com.androidstartupperfapp.screens;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,6 +31,7 @@ public class SecondFragment extends Fragment {
     super.onViewCreated(view, savedInstanceState);
 
     binding.secondNavToThirdButton.setOnClickListener(this::onSecondNavToThirdButtonClick);
+    binding.startReactActivityButton.setOnClickListener(this::onStartReactActivityButtonClick);
   }
 
   @Override
@@ -42,5 +44,13 @@ public class SecondFragment extends Fragment {
     NavHostFragment
       .findNavController(SecondFragment.this)
       .navigate(R.id.action_SecondFragment_to_ThirdFragment);
+  }
+
+  private void onStartReactActivityButtonClick(View view) {
+    // In a fragment, we can't use the current activity (MainActivity) class directly.
+    // However, we can use getActivity() to get the job done.
+    // https://stackoverflow.com/a/15478468/11455106
+    Intent intent = new Intent(getActivity(), ReactActivity.class);
+    startActivity(intent);
   }
 }

--- a/android/app/src/main/res/layout/second_fragment.xml
+++ b/android/app/src/main/res/layout/second_fragment.xml
@@ -27,4 +27,16 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/second_textview" />
+
+  <Button
+    android:id="@+id/start_react_activity_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:backgroundTint="@color/teal_700"
+    android:text="@string/start_react_activity"
+    android:textColor="@color/white"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/second_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
   <string name="third_fragment_label">Third Fragment</string>
   <string name="next">Next</string>
   <string name="previous">Previous</string>
+  <string name="start_react_activity">Start React Activity</string>
 
   <string name="hello_first_fragment">Hello first fragment. This is native.</string>
   <string name="hello_second_fragment">Hello second fragment. This is still native!</string>


### PR DESCRIPTION
## Summary
Starting point: #23

React Native is launched as a separate activity from native Android. This done by implementing a separate activity that tries to imitate as much React activity behavior as is required in order to perform basic React Native operations such as root view unmounting, back button navigation, view host lifecycles, ...

**NOTE:** This integration makes the assumption that the native stack feature of React Navigation exists as a critical dependency for developer's productivity in client code for custom screens in React Native.

https://user-images.githubusercontent.com/67677362/197924303-87f5402c-4380-49c7-a5a2-ab6b1be03d53.mp4

## Notable findings

1. ### Subclassing `Activity` instead of `AppCompatActivity` crashes React Navigation.

    <details>
    <summary>Finding</summary>
    
    When subclassing `Activity`, as suggested in the React Native docs, the app will stop functioning once the end user attempts to launch the React activity portion of the app.
    
    It's possible that React Native Screens expects the behaviors that exist in `AppCompatActivity` which don't exist in `Activity`.
    </details>

2. ### Using `singleTask` as the `launchMode` prevents custom `ReactActivity` from warm starting.

    <details>
    <summary>Finding</summary>
    
    While the default `singleTask` setting from the React Native boilerplate does work, it will always cause the app to resume at the `MainActivity` instead. In that situation, the `ReactActivity.onDestroy()` method was called before `MainActivity.onResume()`.
    
    Setting to `singleTop` changes this behavior somewhat: when the app is restored from the background (it hasn't been killed yet), Android selects the last activity from the app's native stack and resumes from there, thus preserving the activity last viewed by the user. In this case, that last activity should be the custom `ReactActivity`.
    
    The consequences of changing the `launchMode` especially on 3rd-party SDKs is still unknown.
    </details>

3. ### Loading `ReactRootView` on demand introduces a noticeable delay every time custom `ReactActivity` is started.

    <details>
    <summary>Finding</summary>
    
    This approach causes the bundle to always perform a bundle load at app launch, which adds a small moment of delay to UI readiness, thus worsening the perceived loading duration.
    
    No analysis yet.
    
    </details>

## References
- https://reactnative.dev/docs/integration-with-existing-apps
