### PR TITLE
feat(components): add boolean indicator toggle button

### DIFF
--- a/src/components/PositiveToggleButton.tsx
+++ b/src/components/PositiveToggleButton.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Button, ButtonProps } from 'react-native';
+
+const PositiveToggleButton = () => {
+  const [positive, setPositive] = useState(false);
+  const positiveButtonPropsTruthTable: Record<`${boolean}`, ButtonProps> = {
+    false: {
+      title: 'Negative state',
+      color: '#FF0187',
+    },
+    true: {
+      title: 'Positive state',
+      color: '#018786',
+    },
+  };
+  const positiveButtonPropsKey = positive.toString() as keyof typeof positiveButtonPropsTruthTable;
+  const positiveButtonProps = positiveButtonPropsTruthTable[positiveButtonPropsKey];
+  const handlePositiveButtonClick = () => {
+    setPositive(!positive);
+  };
+
+  return (
+    <Button
+      // multiline
+      {...positiveButtonProps}
+      onPress={handlePositiveButtonClick}
+    />
+  );
+};
+
+export default PositiveToggleButton;

--- a/src/flow/ui/screens/HomeScreen.tsx
+++ b/src/flow/ui/screens/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, Text } from 'react-native';
 
+import PositiveToggleButton from '../../../components/PositiveToggleButton';
 import ScreenView from '../../../components/ScreenView';
 
 import useFlowStackNavigatorNavigate from '../../nav/useFlowStackNavigatorNavigate';
@@ -12,6 +13,7 @@ const HomeScreen = () => {
     <ScreenView>
       <Text>Home</Text>
       <Button title="Start" onPress={navigateTo.Step1} />
+      <PositiveToggleButton />
     </ScreenView>
   );
 };


### PR DESCRIPTION
## Summary
To observe whether this custom React button boolean state resets when the Android activity resumes from background (i.e. warm start), regardless of the setup used.
